### PR TITLE
Fix VS Code debugger flow

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,7 @@
 {
     "recommendations": [
         "ms-vscode.cpptools",
-        "ms-vscode.cmake-tools"
+        "ms-vscode.cmake-tools",
+        "vadimcn.vscode-lldb"
     ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,20 +2,38 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "Debug: CMake Target",
+            "name": "Debug: CMake Target (macOS)",
+            "type": "lldb",
+            "request": "launch",
+            "preLaunchTask": "Prepare debug target",
+            "program": "${workspaceFolder}/build/debug/${command:cmake.launchTargetName}",
+            "args": [],
+            "stopAtEntry": false,
+            "cwd": "${workspaceFolder}",
+            "env": {}
+        },
+        {
+            "name": "Debug: CMake Target (Linux)",
             "type": "cppdbg",
             "request": "launch",
-            "program": "${command:cmake.launchTargetPath}",
+            "preLaunchTask": "Prepare debug target",
+            "program": "${workspaceFolder}/build/debug/${command:cmake.launchTargetName}",
             "args": [],
             "stopAtEntry": false,
             "cwd": "${workspaceFolder}",
             "environment": [],
-            "linux": {
-                "MIMode": "gdb"
-            },
-            "osx": {
-                "MIMode": "lldb"
-            }
+            "MIMode": "gdb"
+        },
+        {
+            "name": "Debug: CMake Target (Windows)",
+            "type": "cppvsdbg",
+            "request": "launch",
+            "preLaunchTask": "Prepare debug target",
+            "program": "${workspaceFolder}/build/debug/Debug/${command:cmake.launchTargetName}.exe",
+            "args": [],
+            "stopAtEntry": false,
+            "cwd": "${workspaceFolder}",
+            "environment": []
         }
     ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,7 @@
 {
     "cmake.useCMakePresets": "always",
+    "cmake.buildBeforeRun": false,
+    "C_Cpp.default.configurationProvider": "ms-vscode.cmake-tools",
     "C_Cpp.default.compileCommands": "${workspaceFolder}/compile_commands.json",
     "files.associations": {
         "deque": "cpp",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,19 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Prepare debug target",
+            "type": "shell",
+            "command": "cmake",
+            "args": [
+                "--workflow",
+                "--preset",
+                "debug"
+            ],
+            "options": {
+                "cwd": "${workspaceFolder}"
+            },
+            "problemMatcher": []
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -145,6 +145,11 @@ Use:
 Or run `make bootstrap` to generate both the debug and release Conan presets up front.
 
 Then open the folder, accept the recommended extensions, and select the matching public preset.
+For the checked-in launch configuration, choose the target you want in the CMake Tools sidebar and
+start the platform-specific `Debug: CMake Target (...)` configuration. F5 will run the public
+`debug` workflow first and then launch the selected executable from `build/debug`. On macOS, the
+repository uses the CodeLLDB extension because the system `lldb` does not support the MI protocol
+used by `cppdbg`.
 
 ### CLion
 


### PR DESCRIPTION
## Summary
- add a repo-owned VS Code task that runs the public debug workflow before launch
- switch macOS debugging to CodeLLDB instead of the MI-based cpptools LLDB path
- document the platform-specific VS Code launch flow and recommend the LLDB extension

## Validation
- jq empty .vscode/launch.json .vscode/settings.json .vscode/extensions.json .vscode/tasks.json
- cmake --workflow --preset debug
