### PR TITLE
Simplify build layering and refresh C++23 sample

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest]
 
     steps:
     - name: Checkout
@@ -37,4 +37,4 @@ jobs:
       run: conan install . -s compiler.cppstd=23 -s build_type=Release --lockfile=conan.lock --build=missing
 
     - name: Run CMake workflow
-      run: cmake --workflow --preset ci
+      run: cmake --workflow --preset release

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -23,17 +23,6 @@
             "cwd": "${workspaceFolder}",
             "environment": [],
             "MIMode": "gdb"
-        },
-        {
-            "name": "Debug: CMake Target (Windows)",
-            "type": "cppvsdbg",
-            "request": "launch",
-            "preLaunchTask": "Prepare debug target",
-            "program": "${workspaceFolder}/build/debug/Debug/${command:cmake.launchTargetName}.exe",
-            "args": [],
-            "stopAtEntry": false,
-            "cwd": "${workspaceFolder}",
-            "environment": []
         }
     ]
 }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,11 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 option(ENABLE_ASAN "Enable address sanitizer instrumentation" OFF)
 option(ENABLE_COVERAGE "Enable code coverage instrumentation" OFF)
 
-if(CMAKE_EXPORT_COMPILE_COMMANDS)
+if(
+    CMAKE_EXPORT_COMPILE_COMMANDS
+    AND CMAKE_GENERATOR MATCHES "Ninja|Makefiles"
+    AND NOT CMAKE_BINARY_DIR STREQUAL PROJECT_SOURCE_DIR
+)
     file(REMOVE ${PROJECT_SOURCE_DIR}/compile_commands.json)
     file(
         CREATE_LINK
@@ -29,11 +33,7 @@ endif()
 find_package(Boost 1.74 CONFIG REQUIRED)
 
 function(enable_project_warnings target)
-    if(MSVC)
-        target_compile_options(${target} PRIVATE /W4 /WX /permissive- /EHsc)
-    else()
-        target_compile_options(${target} PRIVATE -Wall -Wextra -Wpedantic -Werror)
-    endif()
+    target_compile_options(${target} PRIVATE -Wall -Wextra -Wpedantic -Werror)
 endfunction()
 
 function(enable_sanitizers target)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.28)
 project(
     cpp-boilerplate
     VERSION 0.1.0
-    DESCRIPTION "Modern C++ boilerplate with Conan and CMake presets"
+    DESCRIPTION "Modern C++23 project template with Conan and CMake"
     LANGUAGES CXX
 )
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -25,29 +25,23 @@
       "name": "asan",
       "displayName": "AddressSanitizer",
       "description": "Debug configuration with address sanitizer enabled.",
-      "inherits": "conan-debug-asan",
-      "condition": {
-        "type": "notEquals",
-        "lhs": "${hostSystemName}",
-        "rhs": "Windows"
+      "inherits": "conan-debug",
+      "binaryDir": "${sourceDir}/build/DebugAsan",
+      "toolchainFile": "${sourceDir}/build/Debug/generators/conan_toolchain.cmake",
+      "cacheVariables": {
+        "ENABLE_ASAN": "ON"
       }
     },
     {
       "name": "coverage",
       "displayName": "Coverage",
       "description": "Debug configuration with coverage instrumentation enabled.",
-      "inherits": "conan-debug-coverage",
-      "condition": {
-        "type": "notEquals",
-        "lhs": "${hostSystemName}",
-        "rhs": "Windows"
+      "inherits": "conan-debug",
+      "binaryDir": "${sourceDir}/build/DebugCoverage",
+      "toolchainFile": "${sourceDir}/build/Debug/generators/conan_toolchain.cmake",
+      "cacheVariables": {
+        "ENABLE_COVERAGE": "ON"
       }
-    },
-    {
-      "name": "ci",
-      "displayName": "ContinuousIntegration",
-      "description": "Release configuration used by CI workflows.",
-      "inherits": "release"
     }
   ],
   "buildPresets": [
@@ -70,11 +64,6 @@
       "name": "coverage",
       "configurePreset": "coverage",
       "configuration": "Debug"
-    },
-    {
-      "name": "ci",
-      "configurePreset": "ci",
-      "configuration": "Release"
     }
   ],
   "testPresets": [
@@ -109,14 +98,6 @@
       "output": {
         "outputOnFailure": true
       }
-    },
-    {
-      "name": "ci",
-      "configurePreset": "ci",
-      "configuration": "Release",
-      "output": {
-        "outputOnFailure": true
-      }
     }
   ],
   "workflowPresets": [
@@ -134,19 +115,53 @@
       ]
     },
     {
-      "name": "ci",
+      "name": "release",
       "steps": [
         {
           "type": "configure",
-          "name": "ci"
+          "name": "release"
         },
         {
           "type": "build",
-          "name": "ci"
+          "name": "release"
         },
         {
           "type": "test",
-          "name": "ci"
+          "name": "release"
+        }
+      ]
+    },
+    {
+      "name": "asan",
+      "steps": [
+        {
+          "type": "configure",
+          "name": "asan"
+        },
+        {
+          "type": "build",
+          "name": "asan"
+        },
+        {
+          "type": "test",
+          "name": "asan"
+        }
+      ]
+    },
+    {
+      "name": "coverage",
+      "steps": [
+        {
+          "type": "configure",
+          "name": "coverage"
+        },
+        {
+          "type": "build",
+          "name": "coverage"
+        },
+        {
+          "type": "test",
+          "name": "coverage"
         }
       ]
     }

--- a/Makefile
+++ b/Makefile
@@ -4,38 +4,40 @@ UNAME_S := $(shell uname -s)
 
 CONAN ?= conan
 CMAKE ?= cmake
-CTEST ?= ctest
 LCOV ?= lcov
 GENHTML ?= genhtml
 
+COLOR_CYAN := \033[36m
+COLOR_RESET := \033[0m
+
 CLANG_FORMAT ?= $(if $(LLVM_BIN),$(LLVM_BIN)/clang-format,clang-format)
 CLANG_TIDY ?= $(if $(LLVM_BIN),$(LLVM_BIN)/clang-tidy,clang-tidy)
+
+.DEFAULT_GOAL := help
 
 ifneq ($(VERBOSE),1)
 .SILENT:
 endif
 
-CONAN_INSTALL_ARGS ?= -s compiler.cppstd=23 --build=missing --lockfile=conan.lock
+.SECONDEXPANSION:
+
+# ---------------------------------------------------------------------------
+# Conan configuration — only two build types. ASan and coverage are just
+# CMake cache variables layered on top of the debug toolchain.
+# ---------------------------------------------------------------------------
+CONAN_STD := -s compiler.cppstd=23
+CONAN_INSTALL_ARGS := $(CONAN_STD) --build=missing --lockfile=conan.lock
+
+CONAN_BUILD_TYPE_debug   := Debug
+CONAN_BUILD_TYPE_release := Release
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+STAMP_DIR := build/.stamps
+COVERAGE_DIR := build/DebugCoverage
 FORMAT_FILES := $(shell find include src tests -type f \( -name '*.hpp' -o -name '*.cpp' \))
 TIDY_SOURCES := $(shell find src tests -type f -name '*.cpp')
-CONAN_INPUTS := conanfile.py conan.lock
-CONAN_BUILD_DIR_debug := build/debug
-CONAN_BUILD_DIR_release := build/release
-CONAN_BUILD_DIR_asan := build/debug-asan
-CONAN_BUILD_DIR_coverage := build/debug-coverage
-CONAN_STAMP_debug := $(CONAN_BUILD_DIR_debug)/.conan.stamp
-CONAN_STAMP_release := $(CONAN_BUILD_DIR_release)/.conan.stamp
-CONAN_STAMP_asan := $(CONAN_BUILD_DIR_asan)/.conan.stamp
-CONAN_STAMP_coverage := $(CONAN_BUILD_DIR_coverage)/.conan.stamp
-CONAN_STAMPS := $(CONAN_STAMP_debug) $(CONAN_STAMP_release) $(CONAN_STAMP_asan) $(CONAN_STAMP_coverage)
-CONAN_BUILD_TYPE_debug := Debug
-CONAN_BUILD_TYPE_release := Release
-CONAN_BUILD_TYPE_asan := Debug
-CONAN_BUILD_TYPE_coverage := Debug
-CONAN_OPTIONS_asan := -o '&:asan=True'
-CONAN_OPTIONS_coverage := -o '&:coverage=True'
-RUN_TESTS_release := 1
-RUN_TESTS_asan := 1
 LCOV_IGNORE_ERRORS_Linux := mismatch
 LCOV_IGNORE_ERRORS_Darwin := format,format,mismatch,unsupported
 LCOV_IGNORE_ERRORS ?= $(LCOV_IGNORE_ERRORS_$(UNAME_S))
@@ -45,81 +47,85 @@ define require-tool
 	command -v $(1) >/dev/null || { echo "$(1) not found"; exit 1; }
 endef
 
-.PHONY: help
-help: ## Show available targets
-	printf "Available targets:\n"
-	sed -n 's/^\([[:alnum:]_%.-][^:]*\):.*##[[:space:]]*\(.*\)$$/\1\t\2/p' $(MAKEFILE_LIST) | \
-	while IFS=$$(printf '\t') read -r target description; do \
-		printf "  %-20s %s\n" "$$target" "$$description"; \
-	done
+# ---------------------------------------------------------------------------
+# Conan lock file (lazy — regenerated when conanfile.py changes)
+# ---------------------------------------------------------------------------
+conan.lock: conanfile.py
+	echo "Regenerating conan.lock..."
+	$(CONAN) lock create . $(CONAN_STD)
 
+# ---------------------------------------------------------------------------
+# Conan install (single generic pattern rule)
+# ---------------------------------------------------------------------------
+$(STAMP_DIR)/%.stamp: conan.lock
+	echo "Installing Conan dependencies ($*)..."
+	mkdir -p $(STAMP_DIR)
+	$(CONAN) install . -s build_type=$(CONAN_BUILD_TYPE_$*) $(CONAN_INSTALL_ARGS)
+	touch $@
+
+# ---------------------------------------------------------------------------
+# Help
+# ---------------------------------------------------------------------------
+.PHONY: help
+help: ## Show this help message
+	@awk 'BEGIN {FS = ":.*##"; printf "Usage: make [options] $(COLOR_CYAN)[target] ...$(COLOR_RESET)\n\n"} \
+	/^[a-zA-Z_-]+:.*##/ {printf "  $(COLOR_CYAN)%-16s$(COLOR_RESET) %s\n", $$1, $$2}' \
+	$(MAKEFILE_LIST)
+
+# ---------------------------------------------------------------------------
+# Conan profile and install targets
+# ---------------------------------------------------------------------------
 .PHONY: conan-profile
 conan-profile: ## Detect the default Conan profile for this machine
 	echo "Detecting Conan profile..."
 	$(CONAN) profile detect --force
 
-conan-debug: $(CONAN_STAMP_debug) ## Generate Conan presets and toolchain files for the debug preset
-conan-release: $(CONAN_STAMP_release) ## Generate Conan presets and toolchain files for the release and ci presets
-conan-asan: $(CONAN_STAMP_asan) ## Generate Conan presets and toolchain files for the asan preset
-conan-coverage: $(CONAN_STAMP_coverage) ## Generate Conan presets and toolchain files for the coverage preset
-
-$(CONAN_STAMP_debug): CONAN_PRESET_NAME = debug
-$(CONAN_STAMP_release): CONAN_PRESET_NAME = release
-$(CONAN_STAMP_asan): CONAN_PRESET_NAME = asan
-$(CONAN_STAMP_coverage): CONAN_PRESET_NAME = coverage
-
-$(CONAN_STAMPS): %/.conan.stamp: $(CONAN_INPUTS)
-	echo "Installing Conan dependencies ($(CONAN_PRESET_NAME))..."
-	$(CONAN) install . -s build_type=$(CONAN_BUILD_TYPE_$(CONAN_PRESET_NAME)) $(CONAN_OPTIONS_$(CONAN_PRESET_NAME)) $(CONAN_INSTALL_ARGS)
-	touch $@
-
 .PHONY: bootstrap
-bootstrap: conan-debug conan-release ## Generate Conan presets for the public debug, release, and ci presets
+bootstrap: $(STAMP_DIR)/debug.stamp $(STAMP_DIR)/release.stamp ## Install Conan dependencies for all presets
 
-.PHONY: build-debug build-release build-asan build-coverage
-build-debug build-release build-asan build-coverage: build-%: conan-%
-	echo "Configuring CMake ($*)..."
-	$(CMAKE) --preset $* $(CMAKE_CONFIGURE_ARGS_$*)
-	echo "Building ($*)..."
-	$(CMAKE) --build --preset $*
+# ---------------------------------------------------------------------------
+# Build + test via workflow presets
+# ---------------------------------------------------------------------------
+CONAN_STAMP_debug    := debug
+CONAN_STAMP_release  := release
+CONAN_STAMP_asan     := debug
+CONAN_STAMP_coverage := debug
 
-.PHONY: debug release asan
-debug release asan: %: build-%
-	$(if $(RUN_TESTS_$@),echo "Running tests ($@)..."; $(CTEST) --preset $@)
+CONAN_STAMP_lint     := debug
 
-.PHONY: ci
-ci: conan-release ## Run the public CI workflow preset
-	echo "Running workflow (ci)..."
-	$(CMAKE) --workflow --preset ci
+.PHONY: debug release asan coverage
+debug:    ## Build via the debug workflow preset
+release:  ## Build and test via the release workflow preset
+asan:     ## Build and test via the asan workflow preset
+coverage: ## Build, test, and generate LCOV coverage report
 
-.PHONY: test-debug test-release test-asan test-coverage
-test-debug test-release test-asan test-coverage: test-%: build-%
-	echo "Running tests ($*)..."
-	$(CTEST) --preset $*
+debug release asan: %: $(STAMP_DIR)/$$(CONAN_STAMP_%).stamp
+	$(CMAKE) --workflow --preset $*
 
-.PHONY: coverage
-coverage: build-coverage ## Generate an LCOV report under build/debug-coverage/coverage-report
-	echo "Generating coverage report..."
+# ---------------------------------------------------------------------------
+# Coverage report generation (appended after the workflow runs tests)
+# ---------------------------------------------------------------------------
+coverage: $(STAMP_DIR)/$$(CONAN_STAMP_coverage).stamp
+	-find $(COVERAGE_DIR) -name '*.gcda' -delete
+	$(CMAKE) --workflow --preset coverage
 	$(call require-tool,$(LCOV))
 	$(call require-tool,$(GENHTML))
-	find build/debug-coverage -name '*.gcda' -delete
-	echo "Running tests (coverage)..."
-	$(CTEST) --preset coverage
 	$(LCOV) --capture \
-		--directory build/debug-coverage \
+		--directory $(COVERAGE_DIR) \
 		--base-directory $(abspath .) \
 		--no-external \
 		$(LCOV_CAPTURE_ARGS) \
-		--output-file build/debug-coverage/coverage.info
-	rm -rf build/debug-coverage/coverage-report
-	$(GENHTML) build/debug-coverage/coverage.info --output-directory build/debug-coverage/coverage-report
+		--output-file $(COVERAGE_DIR)/coverage.info
+	rm -rf $(COVERAGE_DIR)/coverage-report
+	$(GENHTML) $(COVERAGE_DIR)/coverage.info --output-directory $(COVERAGE_DIR)/coverage-report
 
+# ---------------------------------------------------------------------------
+# Lint and format
+# ---------------------------------------------------------------------------
 .PHONY: lint
-lint: conan-debug ## Run clang-tidy against the debug compilation database
-	echo "Configuring CMake (debug)..."
-	$(CMAKE) --preset debug
-	echo "Running clang-tidy..."
+lint: $(STAMP_DIR)/$$(CONAN_STAMP_lint).stamp ## Run clang-tidy against the debug compilation database
 	$(call require-tool,$(CLANG_TIDY))
+	$(CMAKE) --preset debug
 	$(CLANG_TIDY) -p build/debug $(TIDY_SOURCES)
 
 .PHONY: format
@@ -134,11 +140,11 @@ format-check: ## Fail if C++ sources are not clang-format clean
 	$(call require-tool,$(CLANG_FORMAT))
 	$(CLANG_FORMAT) --dry-run --Werror $(FORMAT_FILES)
 
+# ---------------------------------------------------------------------------
+# Lock and clean
+# ---------------------------------------------------------------------------
 .PHONY: lock
-lock: ## Regenerate conan.lock from conanfile.py
-	echo "Regenerating conan.lock..."
-	$(CONAN) lock create . -s compiler.cppstd=23 -s build_type=Debug
-	$(CONAN) lock create . -s compiler.cppstd=23 -s build_type=Release --lockfile=conan.lock --lockfile-out=conan.lock
+lock: conan.lock ## Ensure conan.lock is up to date
 
 .PHONY: clean
 clean: ## Remove generated build artifacts and Conan preset files

--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ A modern C++23 project boilerplate using:
 - [Boost](https://www.boost.org) via Conan for portable utility libraries
 - [GoogleTest](https://github.com/google/googletest) via Conan
 
+The sample code intentionally stays small, but it demonstrates a few C++23-friendly defaults:
+
+- `std::string_view` for lightweight input handling
+- `std::views::transform` in the sample utility pipeline without adding extra template machinery
+
 The project keeps the public presets in the repository and lets Conan generate the toolchain and its
 internal presets:
 

--- a/README.md
+++ b/README.md
@@ -20,23 +20,23 @@ internal presets:
 
 - the project owns [`CMakePresets.json`](CMakePresets.json)
 - Conan generates `ConanPresets.json`
-- the public presets (`debug`, `release`, `asan`, `coverage`, `ci`) inherit from Conan's internal
+- the public presets (`debug`, `release`, `asan`, `coverage`) inherit from Conan's internal
   presets
 
 The checked-in presets are the source of truth. The [`Makefile`](Makefile) is only a thin
 convenience wrapper around `conan install` plus the public CMake presets and workflows.
+
+This repository uses Conan's `CMakeConfigDeps` generator directly.
 
 ## Prerequisites
 
 - CMake 3.28+
 - Conan 2
 - Ninja or GNU Make on Unix-like systems
-- Visual Studio 2022 on Windows
 - A compiler and standard library with working C++23 support
   - GCC 13+
   - LLVM Clang 17+
   - Apple Clang 17+ recommended
-  - MSVC 19.3x or newer on Windows
 
 > [!IMPORTANT]
 > If you are on a very new Apple Clang release, make sure your Conan installation and settings are
@@ -46,7 +46,8 @@ Conan chooses the CMake generator for you:
 
 - `Ninja` on Unix-like systems when it is available
 - `Unix Makefiles` on Unix-like systems when `ninja` is not installed
-- `Visual Studio 17 2022` on Windows
+
+This boilerplate currently supports macOS and Linux.
 
 ## Configure, build, and test
 
@@ -65,7 +66,6 @@ Other local convenience targets:
 make release
 make asan
 make coverage
-make ci
 ```
 
 These targets do not define the build. They just run the matching Conan install command and then
@@ -77,19 +77,25 @@ delegate to the public CMake presets and workflows.
 make asan
 ```
 
-This uses a dedicated ASAN build tree under `build/debug-asan`.
+This uses a dedicated ASAN build tree under `build/DebugAsan`.
 
 > [!NOTE]
 > Conan owns the dependency graph, generator, toolchain, and ABI settings. If you switch the Conan
-> configuration, rerun the matching `make conan-*` target and keep using the same public CMake
-> preset names.
+> configuration, rerun `make bootstrap` or the matching public `make` target and keep using the
+> same public CMake preset names.
+
+### Tests
+
+Tests are controlled by CMake's built-in `BUILD_TESTING` option from `include(CTest)`. This
+project leaves it at the default `ON`, so the `release`, `asan`, and `coverage` workflows run the
+test suite by default.
 
 ## Public presets
 
-- Configure presets: `debug`, `release`, `asan`, `coverage`, `ci`
-- Build presets: `debug`, `release`, `asan`, `coverage`, `ci`
-- Test presets: `debug`, `release`, `asan`, `coverage`, `ci`
-- Workflow presets: `debug`, `ci`
+- Configure presets: `debug`, `release`, `asan`, `coverage`
+- Build presets: `debug`, `release`, `asan`, `coverage`
+- Test presets: `debug`, `release`, `asan`, `coverage`
+- Workflow presets: `debug`, `release`, `asan`, `coverage`
 
 The Conan-generated `conan-*` presets are internal implementation details and are not the public
 interface for developers or CI.
@@ -121,49 +127,30 @@ make coverage
 
 This writes:
 
-- `build/debug-coverage/coverage.info`
-- `build/debug-coverage/coverage-report/index.html`
+- `build/DebugCoverage/coverage.info`
+- `build/DebugCoverage/coverage-report/index.html`
 
 ## Editor setup
 
 ### VS Code
 
 VS Code with CMake Tools will discover the checked-in public presets automatically after Conan
-generates `ConanPresets.json`. Bootstrap the matching Conan configuration first:
-
-```console
-make conan-debug
-```
-
-Use:
-
-- `make conan-debug` for `debug`
-- `make conan-release` for `release` and `ci`
-- `make conan-asan` for `asan`
-- `make conan-coverage` for `coverage`
-
-Or run `make bootstrap` to generate both the debug and release Conan presets up front.
+generates `ConanPresets.json`. Run `make bootstrap` first to generate both debug and release Conan
+toolchains and presets.
 
 Then open the folder, accept the recommended extensions, and select the matching public preset.
 For the checked-in launch configuration, choose the target you want in the CMake Tools sidebar and
 start the platform-specific `Debug: CMake Target (...)` configuration. F5 will run the public
-`debug` workflow first and then launch the selected executable from `build/debug`. On macOS, the
+`debug` workflow first and then launch the selected executable from `build/Debug`. On macOS, the
 repository uses the CodeLLDB extension because the system `lldb` does not support the MI protocol
 used by `cppdbg`.
 
 ### CLion
 
-CLion can use the same public presets. Generate `ConanPresets.json` first:
-
-```console
-make conan-debug
-```
-
-Use the same matching Conan configuration rules as VS Code, or run `make bootstrap` first. Then in
-CLion:
+CLion can use the same public presets. Run `make bootstrap` first, then in CLion:
 
 1. Open the project root
-2. Select the `debug`, `release`, `asan`, or `ci` preset as the active CMake profile
+2. Select the `debug`, `release`, `asan`, or `coverage` preset as the active CMake profile
 3. Reload CMake
 
 > [!NOTE]

--- a/README.md
+++ b/README.md
@@ -8,7 +8,11 @@
 
 ## Overview
 
-A modern C++23 project boilerplate using:
+A modern C++23 project template demonstrating end-to-end toolchain integration: Conan 2 dependency
+management, CMake presets, multi-configuration builds, testing, sanitizers, coverage, CI, and IDE
+seteup.
+
+This repository uses:
 
 - [CMake](https://cmake.org) presets and workflow presets as the public build interface
 - [Conan 2](https://conan.io) for dependency management

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,7 +1,7 @@
 import shutil
 
 from conan import ConanFile
-from conan.tools.cmake import CMakeDeps, CMakeToolchain, cmake_layout
+from conan.tools.cmake import CMakeConfigDeps, CMakeToolchain, cmake_layout
 
 
 class CppBoilerplateConan(ConanFile):
@@ -11,48 +11,26 @@ class CppBoilerplateConan(ConanFile):
     package_type = "application"
 
     settings = "os", "compiler", "build_type", "arch"
-    options = {
-        "asan": [True, False],
-        "coverage": [True, False],
-        "with_tests": [True, False],
-    }
 
     requires = "boost/1.90.0"
 
     default_options = {
-        "asan": False,
-        "coverage": False,
-        "with_tests": True,
         "boost/*:header_only": True,
     }
 
     def _cmake_generator(self):
-        if str(self.settings.os) == "Windows":
-            return "Visual Studio 17 2022"
-
         return "Ninja" if shutil.which("ninja") else "Unix Makefiles"
 
     def layout(self):
-        build_variants = []
-        if self.options.get_safe("asan"):
-            build_variants.append("asan")
-        if self.options.get_safe("coverage"):
-            build_variants.append("coverage")
-        self.build_variant = "-".join(build_variants) if build_variants else None
-        self.folders.build_folder_vars = ["settings.build_type", "self.build_variant"]
         cmake_layout(self, generator=self._cmake_generator())
 
     def build_requirements(self):
-        if self.options.with_tests:
-            self.test_requires("gtest/1.15.0")
+        self.test_requires("gtest/1.15.0")
 
     def generate(self):
-        deps = CMakeDeps(self)
+        deps = CMakeConfigDeps(self)
         deps.generate()
 
         tc = CMakeToolchain(self, generator=self._cmake_generator())
         tc.user_presets_path = "ConanPresets.json"
-        tc.cache_variables["BUILD_TESTING"] = bool(self.options.with_tests)
-        tc.cache_variables["ENABLE_ASAN"] = bool(self.options.asan)
-        tc.cache_variables["ENABLE_COVERAGE"] = bool(self.options.coverage)
         tc.generate()

--- a/include/cpp_boilerplate/record_summary.hpp
+++ b/include/cpp_boilerplate/record_summary.hpp
@@ -5,6 +5,7 @@
 
 #include <cpp_boilerplate/split.hpp>
 
+#include <ranges>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -12,10 +13,14 @@
 inline std::string
 summarize_fields(std::string_view record, char delimiter = ',', std::string_view separator = " | ")
 {
-    std::vector<std::string> fields = split(record, delimiter);
+    std::vector<std::string> fields;
 
-    for (std::string& field : fields) {
+    for (std::string field : split_views(record, delimiter)
+                                 | std::views::transform([](std::string_view value) {
+                                       return std::string{value};
+                                   })) {
         boost::algorithm::trim(field);
+        fields.push_back(std::move(field));
     }
 
     return boost::algorithm::join(fields, std::string{separator});

--- a/include/cpp_boilerplate/split.hpp
+++ b/include/cpp_boilerplate/split.hpp
@@ -4,10 +4,10 @@
 #include <string_view>
 #include <vector>
 
-inline std::vector<std::string>
-split(std::string_view record, char delimiter = ',')
+inline std::vector<std::string_view>
+split_views(std::string_view record, char delimiter = ',')
 {
-    std::vector<std::string> fields;
+    std::vector<std::string_view> fields;
 
     std::size_t begin = 0;
 
@@ -18,6 +18,17 @@ split(std::string_view record, char delimiter = ',')
             break;
         }
         begin = end + 1;
+    }
+
+    return fields;
+}
+inline std::vector<std::string>
+split(std::string_view record, char delimiter = ',')
+{
+    std::vector<std::string> fields;
+
+    for (std::string_view field : split_views(record, delimiter)) {
+        fields.emplace_back(field);
     }
 
     return fields;

--- a/tests/split_test.cpp
+++ b/tests/split_test.cpp
@@ -3,6 +3,7 @@
 #include <cpp_boilerplate/record_summary.hpp>
 #include <cpp_boilerplate/split.hpp>
 
+#include <string_view>
 #include <vector>
 
 TEST(SplitTest, SplitsCommaSeparatedFields)
@@ -39,6 +40,12 @@ TEST(SplitTest, SupportsCustomDelimiter)
 {
     const std::vector<std::string> expected{"left", "middle", "right"};
     EXPECT_EQ(split("left|middle|right", '|'), expected);
+}
+
+TEST(SplitViewTest, ReturnsZeroCopyViews)
+{
+    const std::vector<std::string_view> expected{"52930489", "aaa", "18", "1222"};
+    EXPECT_EQ(split_views("52930489,aaa,18,1222"), expected);
 }
 
 TEST(RecordSummaryTest, TrimsWhitespaceBeforeJoiningFields)


### PR DESCRIPTION
## Summary
- simplify the Conan, CMake preset, and Make layering so Conan only owns toolchains and dependencies while CMake presets own the build matrix
- fix the coverage workflow and align custom build directories with the existing `Debug`/`Release` naming convention
- refresh the sample code to showcase `std::string_view`, zero-copy splitting, and `std::views::transform`, and update the README accordingly

## Verification
- make release
- make coverage LCOV=true GENHTML=true
- make lint
