### PR TITLE
build: align presets and bootstrap workflow

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,15 +1,14 @@
 # Requires clang-format >= 16
 BasedOnStyle: LLVM
-Standard: Latest
+Standard: c++20
 #
 AccessModifierOffset: -4
-AlignConsecutiveAssignments: true
+AlignConsecutiveAssignments: false
 AlignEscapedNewlines: Left
 AlignOperands: true
 AlignTrailingComments: true
-AlignConsecutiveDeclarations: true
+AlignConsecutiveDeclarations: false
 AllowShortFunctionsOnASingleLine: Inline
-BreakAfterReturnType: TopLevelDefinitions
 AlwaysBreakTemplateDeclarations: false
 BreakBeforeBraces: Stroustrup
 ColumnLimit: 100
@@ -19,6 +18,6 @@ IndentCaseLabels: false
 IndentWidth: 4
 KeepEmptyLinesAtTheStartOfBlocks: false
 PointerAlignment: Left
-SortIncludes: false
+SortIncludes: CaseSensitive
 SpaceAfterCStyleCast: true
 # vim: ft=yaml

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,9 @@
 FormatStyle: file
-WarningsAsErrors: '*'
+WarningsAsErrors: >
+  bugprone-*,
+  clang-analyzer-*,
+  performance-*,
+  -performance-avoid-endl
 HeaderFilterRegex: '^(include|src|tests)/'
 
 Checks: >

--- a/.editorconfig
+++ b/.editorconfig
@@ -14,3 +14,10 @@ indent_size = 4
 [*.json]
 indent_style = space
 indent_size = 4
+
+[*.{hpp,cpp,h,c}]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,39 +2,71 @@ name: Build
 
 on:
   push:
-    branches: main
+    branches: [main]
   pull_request:
-    branches: main
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
-  ci:
-    name: CI (${{ matrix.os }})
+  build:
+    name: ${{ matrix.preset }} / ${{ matrix.os }} / ${{ matrix.compiler }}
     runs-on: ${{ matrix.os }}
+    env:
+      CC: ${{ matrix.compiler == 'gcc' && 'gcc' || 'clang' }}
+      CXX: ${{ matrix.compiler == 'gcc' && 'g++' || 'clang++' }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-24.04, macos-15]
+        preset: [release, sanitize, coverage]
+        compiler: [gcc, clang]
+        exclude:
+          - os: macos-15
+            compiler: gcc
 
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v4
+        with:
+          path: ~/.conan2
+          key: conan-${{ matrix.os }}-${{ matrix.compiler }}-${{ hashFiles('conanfile.py', 'conan.lock') }}
+          restore-keys: conan-${{ matrix.os }}-${{ matrix.compiler }}-
+      - uses: conan-io/setup-conan@v1
+      - name: Pick host profile
+        id: profile
+        shell: bash
+        run: |
+          case "${{ runner.os }}-${{ matrix.compiler }}" in
+            Linux-gcc)   echo "path=profiles/linux" >> "$GITHUB_OUTPUT" ;;
+            Linux-clang) echo "path=profiles/linux-clang" >> "$GITHUB_OUTPUT" ;;
+            macOS-clang) echo "path=profiles/macos" >> "$GITHUB_OUTPUT" ;;
+            *)           echo "unsupported runner/compiler: ${{ runner.os }}-${{ matrix.compiler }}" >&2; exit 1 ;;
+          esac
+      - name: Verify conan.lock freshness
+        run: |
+          conan lock create . -pr=${{ steps.profile.outputs.path }} -s compiler.cppstd=23 --lockfile-out=/tmp/fresh.lock
+          diff conan.lock /tmp/fresh.lock
+      - run: CONAN_PROFILE=${{ steps.profile.outputs.path }} make bootstrap
+      - run: cmake --preset ${{ matrix.preset }} -DWARNINGS_AS_ERRORS=ON
+      - run: cmake --build --preset ${{ matrix.preset }}
+      - run: ctest --preset ${{ matrix.preset }}
+      - if: matrix.preset == 'coverage'
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-${{ matrix.os }}-${{ matrix.compiler }}
+          path: build/coverage/coverage-report/
 
-    - name: Cache Conan packages
-      uses: actions/cache@v4
-      with:
-        path: ~/.conan2
-        key: conan-${{ matrix.os }}-${{ hashFiles('conanfile.py', 'conan.lock') }}
-        restore-keys: |
-          conan-${{ matrix.os }}-
-
-    - name: Set up Conan
-      uses: conan-io/setup-conan@v1
-
-    - name: Detect Conan profile
-      run: conan profile detect --force
-
-    - name: Install Conan dependencies
-      run: conan install . -s compiler.cppstd=23 -s build_type=Release --lockfile=conan.lock --build=missing
-
-    - name: Run CMake workflow
-      run: cmake --workflow --preset release
+  lint:
+    runs-on: ubuntu-24.04
+    env:
+      CC: gcc
+      CXX: g++
+    steps:
+      - uses: actions/checkout@v4
+      - uses: conan-io/setup-conan@v1
+      - run: make bootstrap
+      - run: make format-check
+      - run: make lint

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,27 +2,13 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "Debug: CMake Target (macOS)",
+            "name": "Debug: CMake Target",
             "type": "lldb",
             "request": "launch",
             "preLaunchTask": "Prepare debug target",
             "program": "${workspaceFolder}/build/debug/${command:cmake.launchTargetName}",
             "args": [],
-            "stopAtEntry": false,
-            "cwd": "${workspaceFolder}",
-            "env": {}
-        },
-        {
-            "name": "Debug: CMake Target (Linux)",
-            "type": "cppdbg",
-            "request": "launch",
-            "preLaunchTask": "Prepare debug target",
-            "program": "${workspaceFolder}/build/debug/${command:cmake.launchTargetName}",
-            "args": [],
-            "stopAtEntry": false,
-            "cwd": "${workspaceFolder}",
-            "environment": [],
-            "MIMode": "gdb"
+            "cwd": "${workspaceFolder}"
         }
     ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,11 +2,5 @@
     "cmake.useCMakePresets": "always",
     "cmake.buildBeforeRun": false,
     "C_Cpp.default.configurationProvider": "ms-vscode.cmake-tools",
-    "C_Cpp.default.compileCommands": "${workspaceFolder}/compile_commands.json",
-    "files.associations": {
-        "deque": "cpp",
-        "list": "cpp",
-        "vector": "cpp",
-        "thread": "cpp"
-    }
+    "C_Cpp.default.compileCommands": "${workspaceFolder}/compile_commands.json"
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -6,9 +6,11 @@
             "type": "shell",
             "command": "cmake",
             "args": [
-                "--workflow",
+                "--build",
                 "--preset",
-                "debug"
+                "debug",
+                "--target",
+                "${command:cmake.launchTargetName}"
             ],
             "options": {
                 "cwd": "${workspaceFolder}"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.28)
 
 project(
-    cpp-boilerplate
+    cpp_boilerplate
     VERSION 0.1.0
     DESCRIPTION "Modern C++23 project template with Conan and CMake"
     LANGUAGES CXX
@@ -12,7 +12,8 @@ include(CTest)
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
-option(ENABLE_ASAN "Enable address sanitizer instrumentation" OFF)
+option(WARNINGS_AS_ERRORS "Treat warnings as errors" OFF)
+option(ENABLE_SANITIZERS "Enable sanitizer instrumentation" OFF)
 option(ENABLE_COVERAGE "Enable code coverage instrumentation" OFF)
 
 if(
@@ -33,20 +34,26 @@ endif()
 find_package(spdlog CONFIG REQUIRED)
 
 function(enable_project_warnings target)
-    target_compile_options(${target} PRIVATE -Wall -Wextra -Wpedantic -Werror)
+    target_compile_options(${target} PRIVATE -Wall -Wextra -Wpedantic)
+    if(WARNINGS_AS_ERRORS)
+        set_target_properties(${target} PROPERTIES COMPILE_WARNING_AS_ERROR ON)
+    endif()
 endfunction()
 
 function(enable_sanitizers target)
-    if(NOT ENABLE_ASAN)
+    if(NOT ENABLE_SANITIZERS)
         return()
     endif()
 
     if(NOT CMAKE_CXX_COMPILER_ID MATCHES "^(GNU|Clang|AppleClang)$")
-        message(FATAL_ERROR "Address sanitizer requires GCC, Clang, or AppleClang")
+        message(FATAL_ERROR "Sanitizers require GCC, Clang, or AppleClang")
     endif()
 
-    target_compile_options(${target} PRIVATE -fsanitize=address -fno-omit-frame-pointer)
-    target_link_options(${target} PRIVATE -fsanitize=address)
+    target_compile_options(${target} PRIVATE
+        -fsanitize=address,undefined
+        -fno-sanitize-recover=all
+        -fno-omit-frame-pointer)
+    target_link_options(${target} PRIVATE -fsanitize=address,undefined)
 endfunction()
 
 function(enable_coverage target)
@@ -90,5 +97,5 @@ if(BUILD_TESTING)
     enable_project_warnings(split_test)
     enable_sanitizers(split_test)
     enable_coverage(split_test)
-    gtest_discover_tests(split_test)
+    gtest_discover_tests(split_test DISCOVERY_MODE PRE_TEST)
 endif()

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -13,23 +13,27 @@
       "name": "debug",
       "displayName": "Debug",
       "description": "Debug configuration backed by Conan's debug preset.",
-      "inherits": "conan-debug"
+      "inherits": "conan-debug",
+      "binaryDir": "${sourceDir}/build/debug",
+      "toolchainFile": "${sourceDir}/build/debug/generators/conan_toolchain.cmake"
     },
     {
       "name": "release",
       "displayName": "Release",
       "description": "Release configuration backed by Conan's release preset.",
-      "inherits": "conan-release"
+      "inherits": "conan-release",
+      "binaryDir": "${sourceDir}/build/release",
+      "toolchainFile": "${sourceDir}/build/release/generators/conan_toolchain.cmake"
     },
     {
-      "name": "asan",
-      "displayName": "AddressSanitizer",
-      "description": "Debug configuration with address sanitizer enabled.",
+      "name": "sanitize",
+      "displayName": "Sanitizers",
+      "description": "Debug configuration with sanitizer instrumentation enabled.",
       "inherits": "conan-debug",
-      "binaryDir": "${sourceDir}/build/DebugAsan",
-      "toolchainFile": "${sourceDir}/build/Debug/generators/conan_toolchain.cmake",
+      "binaryDir": "${sourceDir}/build/sanitize",
+      "toolchainFile": "${sourceDir}/build/debug/generators/conan_toolchain.cmake",
       "cacheVariables": {
-        "ENABLE_ASAN": "ON"
+        "ENABLE_SANITIZERS": "ON"
       }
     },
     {
@@ -37,8 +41,8 @@
       "displayName": "Coverage",
       "description": "Debug configuration with coverage instrumentation enabled.",
       "inherits": "conan-debug",
-      "binaryDir": "${sourceDir}/build/DebugCoverage",
-      "toolchainFile": "${sourceDir}/build/Debug/generators/conan_toolchain.cmake",
+      "binaryDir": "${sourceDir}/build/coverage",
+      "toolchainFile": "${sourceDir}/build/debug/generators/conan_toolchain.cmake",
       "cacheVariables": {
         "ENABLE_COVERAGE": "ON"
       }
@@ -56,8 +60,8 @@
       "configuration": "Release"
     },
     {
-      "name": "asan",
-      "configurePreset": "asan",
+      "name": "sanitize",
+      "configurePreset": "sanitize",
       "configuration": "Debug"
     },
     {
@@ -84,8 +88,8 @@
       }
     },
     {
-      "name": "asan",
-      "configurePreset": "asan",
+      "name": "sanitize",
+      "configurePreset": "sanitize",
       "configuration": "Debug",
       "output": {
         "outputOnFailure": true
@@ -132,19 +136,19 @@
       ]
     },
     {
-      "name": "asan",
+      "name": "sanitize",
       "steps": [
         {
           "type": "configure",
-          "name": "asan"
+          "name": "sanitize"
         },
         {
           "type": "build",
-          "name": "asan"
+          "name": "sanitize"
         },
         {
           "type": "test",
-          "name": "asan"
+          "name": "sanitize"
         }
       ]
     },

--- a/Makefile
+++ b/Makefile
@@ -4,11 +4,11 @@ UNAME_S := $(shell uname -s)
 
 CONAN ?= conan
 CMAKE ?= cmake
-LCOV ?= lcov
-GENHTML ?= genhtml
+GCOVR ?= gcovr
 
 COLOR_CYAN := \033[36m
 COLOR_RESET := \033[0m
+CONAN_PRESETS := ConanPresets.json
 
 CLANG_FORMAT ?= $(if $(LLVM_BIN),$(LLVM_BIN)/clang-format,clang-format)
 CLANG_TIDY ?= $(if $(LLVM_BIN),$(LLVM_BIN)/clang-tidy,clang-tidy)
@@ -21,12 +21,27 @@ endif
 
 .SECONDEXPANSION:
 
+define bootstrap-check
+@if [ ! -f $(CONAN_PRESETS) ]; then \
+	echo "error: $(CONAN_PRESETS) missing. Run 'make bootstrap' first." >&2; \
+	exit 1; \
+fi
+endef
+
 # ---------------------------------------------------------------------------
-# Conan configuration — only two build types. ASan and coverage are just
+# Conan configuration — only two build types. Sanitizers and coverage are just
 # CMake cache variables layered on top of the debug toolchain.
 # ---------------------------------------------------------------------------
 CONAN_STD := -s compiler.cppstd=23
-CONAN_INSTALL_ARGS := $(CONAN_STD) --build=missing --lockfile=conan.lock
+CONAN_PROFILE_Linux := profiles/linux
+CONAN_PROFILE_Darwin := profiles/macos
+CONAN_PROFILE ?= $(CONAN_PROFILE_$(UNAME_S))
+
+ifeq ($(CONAN_PROFILE),)
+$(error unsupported host OS '$(UNAME_S)'; set CONAN_PROFILE=profiles/<name> to override)
+endif
+
+CONAN_INSTALL_ARGS := $(CONAN_STD) --build=missing --lockfile=conan.lock -pr=$(CONAN_PROFILE)
 
 CONAN_BUILD_TYPE_debug   := Debug
 CONAN_BUILD_TYPE_release := Release
@@ -35,13 +50,9 @@ CONAN_BUILD_TYPE_release := Release
 # Paths
 # ---------------------------------------------------------------------------
 STAMP_DIR := build/.stamps
-COVERAGE_DIR := build/DebugCoverage
-FORMAT_FILES := $(shell find include src tests -type f \( -name '*.hpp' -o -name '*.cpp' \))
+COVERAGE_DIR := build/coverage
+FORMAT_FILES = $(shell find include src tests -type f \( -name '*.hpp' -o -name '*.cpp' \))
 TIDY_SOURCES := $(shell find src tests -type f -name '*.cpp')
-LCOV_IGNORE_ERRORS_Linux := mismatch
-LCOV_IGNORE_ERRORS_Darwin := format,format,mismatch,unsupported
-LCOV_IGNORE_ERRORS ?= $(LCOV_IGNORE_ERRORS_$(UNAME_S))
-LCOV_CAPTURE_ARGS := $(if $(LCOV_IGNORE_ERRORS),--ignore-errors $(LCOV_IGNORE_ERRORS),)
 
 define require-tool
 	command -v $(1) >/dev/null || { echo "$(1) not found"; exit 1; }
@@ -50,9 +61,9 @@ endef
 # ---------------------------------------------------------------------------
 # Conan lock file (lazy — regenerated when conanfile.py changes)
 # ---------------------------------------------------------------------------
-conan.lock: conanfile.py
+conan.lock: conanfile.py $(CONAN_PROFILE)
 	echo "Regenerating conan.lock..."
-	$(CONAN) lock create . $(CONAN_STD)
+	$(CONAN) lock create . $(CONAN_STD) -pr=$(CONAN_PROFILE) --lockfile-out=conan.lock
 
 # ---------------------------------------------------------------------------
 # Conan install (single generic pattern rule)
@@ -72,58 +83,45 @@ help: ## Show this help message
 	/^[a-zA-Z_-]+:.*##/ {printf "  $(COLOR_CYAN)%-16s$(COLOR_RESET) %s\n", $$1, $$2}' \
 	$(MAKEFILE_LIST)
 
-# ---------------------------------------------------------------------------
-# Conan profile and install targets
-# ---------------------------------------------------------------------------
-.PHONY: conan-profile
-conan-profile: ## Detect the default Conan profile for this machine
-	echo "Detecting Conan profile..."
-	$(CONAN) profile detect --force
-
 .PHONY: bootstrap
 bootstrap: $(STAMP_DIR)/debug.stamp $(STAMP_DIR)/release.stamp ## Install Conan dependencies for all presets
 
 # ---------------------------------------------------------------------------
 # Build + test via workflow presets
 # ---------------------------------------------------------------------------
-CONAN_STAMP_debug    := debug
-CONAN_STAMP_release  := release
-CONAN_STAMP_asan     := debug
-CONAN_STAMP_coverage := debug
-
-CONAN_STAMP_lint     := debug
-
-.PHONY: debug release asan coverage
+.PHONY: debug release sanitize coverage
 debug:    ## Build via the debug workflow preset
 release:  ## Build and test via the release workflow preset
-asan:     ## Build and test via the asan workflow preset
-coverage: ## Build, test, and generate LCOV coverage report
+sanitize: ## Build and test via the sanitize workflow preset
+coverage: ## Build, test, and generate gcovr coverage report
 
-debug release asan: %: $(STAMP_DIR)/$$(CONAN_STAMP_%).stamp
-	$(CMAKE) --workflow --preset $*
+debug release sanitize:
+	$(call bootstrap-check)
+	$(CMAKE) --workflow --preset $@
 
 # ---------------------------------------------------------------------------
 # Coverage report generation (appended after the workflow runs tests)
 # ---------------------------------------------------------------------------
-coverage: $(STAMP_DIR)/$$(CONAN_STAMP_coverage).stamp
+coverage:
+	$(call bootstrap-check)
 	-find $(COVERAGE_DIR) -name '*.gcda' -delete
 	$(CMAKE) --workflow --preset coverage
-	$(call require-tool,$(LCOV))
-	$(call require-tool,$(GENHTML))
-	$(LCOV) --capture \
-		--directory $(COVERAGE_DIR) \
-		--base-directory $(abspath .) \
-		--no-external \
-		$(LCOV_CAPTURE_ARGS) \
-		--output-file $(COVERAGE_DIR)/coverage.info
-	rm -rf $(COVERAGE_DIR)/coverage-report
-	$(GENHTML) $(COVERAGE_DIR)/coverage.info --output-directory $(COVERAGE_DIR)/coverage-report
+	$(call require-tool,$(GCOVR))
+	mkdir -p $(COVERAGE_DIR)/coverage-report
+	$(GCOVR) --root . \
+		--filter 'include/' --filter 'src/' \
+		--exclude 'tests/' \
+		--html-details $(COVERAGE_DIR)/coverage-report/index.html \
+		--cobertura $(COVERAGE_DIR)/coverage.xml \
+		--txt-summary \
+		$(COVERAGE_DIR)
 
 # ---------------------------------------------------------------------------
 # Lint and format
 # ---------------------------------------------------------------------------
 .PHONY: lint
-lint: $(STAMP_DIR)/$$(CONAN_STAMP_lint).stamp ## Run clang-tidy against the debug compilation database
+lint: ## Run clang-tidy against the debug compilation database
+	$(call bootstrap-check)
 	$(call require-tool,$(CLANG_TIDY))
 	$(CMAKE) --preset debug
 	$(CLANG_TIDY) -p build/debug $(TIDY_SOURCES)
@@ -136,6 +134,7 @@ format: ## Format C++ sources in place with clang-format
 
 .PHONY: format-check
 format-check: ## Fail if C++ sources are not clang-format clean
+	$(call bootstrap-check)
 	echo "Checking C++ formatting..."
 	$(call require-tool,$(CLANG_FORMAT))
 	$(CLANG_FORMAT) --dry-run --Werror $(FORMAT_FILES)

--- a/README.md
+++ b/README.md
@@ -8,48 +8,28 @@
 
 ## Overview
 
-A modern C++23 project template demonstrating end-to-end toolchain integration: Conan 2 dependency
-management, CMake presets, multi-configuration builds, testing, sanitizers, coverage, CI, and IDE
-seteup.
+A modern C++23 project template demonstrating end-to-end toolchain integration: Conan 2.5+
+dependency management, CMake presets, testing, sanitizers, coverage, CI, and IDE setup.
 
 This repository uses:
 
 - [CMake](https://cmake.org) presets and workflow presets as the public build interface
 - [Conan 2](https://conan.io) for dependency management
-- [Boost](https://www.boost.org) via Conan for portable utility libraries
+- [spdlog](https://github.com/gabime/spdlog) via Conan as the sample compiled dependency
 - [GoogleTest](https://github.com/google/googletest) via Conan
 
-The sample code intentionally stays small, but it demonstrates a few C++23-friendly defaults:
-
-- `std::string_view` for lightweight input handling
-- `std::views::transform` in the sample utility pipeline without adding extra template machinery
-
-The project keeps the public presets in the repository and lets Conan generate the toolchain and its
-internal presets:
-
-- the project owns [`CMakePresets.json`](CMakePresets.json)
-- Conan generates `ConanPresets.json`
-- the public presets (`debug`, `release`, `asan`, `coverage`) inherit from Conan's internal
-  presets
-
-The checked-in presets are the source of truth. The [`Makefile`](Makefile) is only a thin
-convenience wrapper around `conan install` plus the public CMake presets and workflows.
-
-This repository uses Conan's `CMakeConfigDeps` generator directly.
+The checked-in presets are the source of truth. [`Makefile`](Makefile) is a thin convenience
+wrapper around `make bootstrap` plus the public CMake presets and workflows.
 
 ## Prerequisites
 
 - CMake 3.28+
-- Conan 2
+- Conan 2.5+
 - Ninja or GNU Make on Unix-like systems
 - A compiler and standard library with working C++23 support
   - GCC 13+
   - LLVM Clang 17+
   - Apple Clang 17+ recommended
-
-> [!IMPORTANT]
-> If you are on a very new Apple Clang release, make sure your Conan installation and settings are
-> up to date before running `conan profile detect`.
 
 Conan chooses the CMake generator for you:
 
@@ -65,7 +45,7 @@ This boilerplate currently supports macOS and Linux.
 ```console
 git clone https://github.com/megabyde/cpp-boilerplate.git
 cd cpp-boilerplate
-make conan-profile
+make bootstrap
 make debug
 ```
 
@@ -73,38 +53,47 @@ Other local convenience targets:
 
 ```console
 make release
-make asan
+make sanitize
 make coverage
+make lint
+make format-check
 ```
 
-These targets do not define the build. They just run the matching Conan install command and then
-delegate to the public CMake presets and workflows.
+### Why CMakePresets.json includes ConanPresets.json
 
-### AddressSanitizer
+The checked-in `CMakePresets.json` owns the public preset names. Conan owns toolchain details. The
+generated `ConanPresets.json` is an implementation detail, not an interface; `make bootstrap` is
+the one-time per-clone step that materializes it.
+
+### Sanitizers
 
 ```console
-make asan
+make sanitize
 ```
 
-This uses a dedicated ASAN build tree under `build/DebugAsan`.
+This uses a dedicated sanitizer build tree under `build/sanitize`.
 
 > [!NOTE]
 > Conan owns the dependency graph, generator, toolchain, and ABI settings. If you switch the Conan
 > configuration, rerun `make bootstrap` or the matching public `make` target and keep using the
 > same public CMake preset names.
 
+> [!NOTE]
+> Sanitizer instrumentation currently applies to first-party code only. Conan dependencies are built
+> with the selected debug profile, not a dedicated sanitizer profile overlay.
+
 ### Tests
 
 Tests are controlled by CMake's built-in `BUILD_TESTING` option from `include(CTest)`. This
-project leaves it at the default `ON`, so the `release`, `asan`, and `coverage` workflows run the
+project leaves it at the default `ON`, so the `release`, `sanitize`, and `coverage` workflows run the
 test suite by default.
 
 ## Public presets
 
-- Configure presets: `debug`, `release`, `asan`, `coverage`
-- Build presets: `debug`, `release`, `asan`, `coverage`
-- Test presets: `debug`, `release`, `asan`, `coverage`
-- Workflow presets: `debug`, `release`, `asan`, `coverage`
+- Configure presets: `debug`, `release`, `sanitize`, `coverage`
+- Build presets: `debug`, `release`, `sanitize`, `coverage`
+- Test presets: `debug`, `release`, `sanitize`, `coverage`
+- Workflow presets: `debug`, `release`, `sanitize`, `coverage`
 
 The Conan-generated `conan-*` presets are internal implementation details and are not the public
 interface for developers or CI.
@@ -128,7 +117,7 @@ make lint
 
 ## Coverage
 
-Generate an LCOV tracefile and HTML report with:
+Generate a gcovr Cobertura report and HTML report with:
 
 ```console
 make coverage
@@ -136,35 +125,31 @@ make coverage
 
 This writes:
 
-- `build/DebugCoverage/coverage.info`
-- `build/DebugCoverage/coverage-report/index.html`
+- `build/coverage/coverage.xml`
+- `build/coverage/coverage-report/index.html`
 
-## Editor setup
+## IDE setup
 
 ### VS Code
 
 VS Code with CMake Tools will discover the checked-in public presets automatically after Conan
-generates `ConanPresets.json`. Run `make bootstrap` first to generate both debug and release Conan
-toolchains and presets.
+generates `ConanPresets.json`. Run `make bootstrap` first.
 
 Then open the folder, accept the recommended extensions, and select the matching public preset.
 For the checked-in launch configuration, choose the target you want in the CMake Tools sidebar and
-start the platform-specific `Debug: CMake Target (...)` configuration. F5 will run the public
-`debug` workflow first and then launch the selected executable from `build/Debug`. On macOS, the
-repository uses the CodeLLDB extension because the system `lldb` does not support the MI protocol
-used by `cppdbg`.
+start `Debug: CMake Target`. F5 builds the selected debug target and launches it from `build/debug`.
 
 ### CLion
 
 CLion can use the same public presets. Run `make bootstrap` first, then in CLion:
 
 1. Open the project root
-2. Select the `debug`, `release`, `asan`, or `coverage` preset as the active CMake profile
+2. Select the `debug`, `release`, `sanitize`, or `coverage` preset as the active CMake profile
 3. Reload CMake
 
 > [!NOTE]
 > No IDE-specific task files are required for the build. The presets are the source of truth.
-> `debug`, `asan`, and `coverage` each use their own build tree, so switching between them does not
+> `debug`, `sanitize`, and `coverage` each use their own build tree, so switching between them does not
 > require forcing a fresh reconfigure.
 
 ## Layout

--- a/conanfile.py
+++ b/conanfile.py
@@ -5,7 +5,7 @@ from conan.tools.cmake import CMakeConfigDeps, CMakeToolchain, cmake_layout
 
 
 class CppBoilerplateConan(ConanFile):
-    required_conan_version = ">=2.0"
+    required_conan_version = ">=2.5"
     name = "cpp-boilerplate"
     version = "0.1.0"
     package_type = "application"
@@ -24,12 +24,17 @@ class CppBoilerplateConan(ConanFile):
         return "Ninja" if shutil.which("ninja") else "Unix Makefiles"
 
     def layout(self):
-        cmake_layout(self, generator=self._cmake_generator())
+        cmake_layout(self, generator=self._cmake_generator(), build_folder="build")
+        bt = str(self.settings.build_type).lower()
+        self.folders.build = f"build/{bt}"
+        self.folders.generators = f"{self.folders.build}/generators"
 
     def build_requirements(self):
         self.test_requires("gtest/1.15.0")
 
     def generate(self):
+        # CMakeConfigDeps (Conan 2.x) generates CMake CONFIG find_package files under
+        # the build dir. Preferred over the legacy CMakeDeps generator.
         deps = CMakeConfigDeps(self)
         deps.generate()
 

--- a/include/cpp_boilerplate/split.hpp
+++ b/include/cpp_boilerplate/split.hpp
@@ -6,8 +6,7 @@
 
 namespace cpp_boilerplate {
 
-inline std::vector<std::string_view>
-split_views(std::string_view record, char delimiter = ',')
+inline std::vector<std::string_view> split_views(std::string_view record, char delimiter = ',')
 {
     std::vector<std::string_view> fields;
 
@@ -25,8 +24,7 @@ split_views(std::string_view record, char delimiter = ',')
     return fields;
 }
 
-inline std::vector<std::string>
-split(std::string_view record, char delimiter = ',')
+inline std::vector<std::string> split(std::string_view record, char delimiter = ',')
 {
     std::vector<std::string> fields;
 

--- a/profiles/linux
+++ b/profiles/linux
@@ -1,0 +1,8 @@
+[settings]
+os=Linux
+arch=x86_64
+compiler=gcc
+compiler.version=13
+compiler.cppstd=23
+compiler.libcxx=libstdc++11
+build_type=Release

--- a/profiles/linux-clang
+++ b/profiles/linux-clang
@@ -1,0 +1,8 @@
+[settings]
+os=Linux
+arch=x86_64
+compiler=clang
+compiler.version=17
+compiler.cppstd=23
+compiler.libcxx=libstdc++11
+build_type=Release

--- a/profiles/macos
+++ b/profiles/macos
@@ -1,0 +1,8 @@
+[settings]
+os=Macos
+arch=armv8
+compiler=apple-clang
+compiler.version=17
+compiler.cppstd=23
+compiler.libcxx=libc++
+build_type=Release

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,3 +1,4 @@
+#include <cstddef>
 #include <exception>
 #include <string_view>
 
@@ -7,8 +8,7 @@
 
 namespace {
 
-void
-run()
+void run()
 {
     spdlog::set_pattern("[%Y-%m-%d %H:%M:%S.%e] [%^%l%$] %v");
     spdlog::info("cpp-boilerplate starting");
@@ -23,15 +23,17 @@ run()
 
 } // namespace
 
-int
-main()
+// NOLINTNEXTLINE(bugprone-exception-escape)
+int main()
 {
     try {
         run();
         return 0;
-    } catch (const std::exception& error) {
+    }
+    catch (const std::exception& error) {
         spdlog::critical("fatal: {}", error.what());
-    } catch (...) {
+    }
+    catch (...) {
         spdlog::critical("fatal: unknown exception");
     }
     return 1;


### PR DESCRIPTION
## Summary
- normalize CMake/Conan build output paths and switch bootstrap to checked-in host profiles
- rename the sanitizer workflow, replace lcov with gcovr, and update CI to use the documented runner toolchains
- refresh README and editor/tooling config to match the new preset/bootstrap flow

## Testing
- make clean
- make debug
- make bootstrap
- make debug
- make release
- make sanitize
- make coverage
- make format-check
- make lint