### PR TITLE
Fix build flow and simplify Makefile

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,6 +43,8 @@ jobs:
       - if: matrix.preset == 'coverage'
         run: python3 -m pip install --break-system-packages --user gcovr
       - run: make bootstrap
+      - if: matrix.preset == 'sanitize'
+        run: make bootstrap-sanitize
       - run: make ${{ matrix.preset }}
       - if: matrix.preset == 'coverage'
         uses: actions/upload-artifact@v4

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -29,9 +29,9 @@
       "name": "sanitize",
       "displayName": "Sanitizers",
       "description": "Debug configuration with sanitizer instrumentation enabled.",
-      "inherits": "conan-debug",
+      "inherits": "conan-sanitize-debug",
       "binaryDir": "${sourceDir}/build/sanitize",
-      "toolchainFile": "${sourceDir}/build/debug/generators/conan_toolchain.cmake",
+      "toolchainFile": "${sourceDir}/build/sanitize/generators/conan_toolchain.cmake",
       "cacheVariables": {
         "ENABLE_SANITIZERS": "ON"
       }
@@ -102,72 +102,6 @@
       "output": {
         "outputOnFailure": true
       }
-    }
-  ],
-  "workflowPresets": [
-    {
-      "name": "debug",
-      "steps": [
-        {
-          "type": "configure",
-          "name": "debug"
-        },
-        {
-          "type": "build",
-          "name": "debug"
-        }
-      ]
-    },
-    {
-      "name": "release",
-      "steps": [
-        {
-          "type": "configure",
-          "name": "release"
-        },
-        {
-          "type": "build",
-          "name": "release"
-        },
-        {
-          "type": "test",
-          "name": "release"
-        }
-      ]
-    },
-    {
-      "name": "sanitize",
-      "steps": [
-        {
-          "type": "configure",
-          "name": "sanitize"
-        },
-        {
-          "type": "build",
-          "name": "sanitize"
-        },
-        {
-          "type": "test",
-          "name": "sanitize"
-        }
-      ]
-    },
-    {
-      "name": "coverage",
-      "steps": [
-        {
-          "type": "configure",
-          "name": "coverage"
-        },
-        {
-          "type": "build",
-          "name": "coverage"
-        },
-        {
-          "type": "test",
-          "name": "coverage"
-        }
-      ]
     }
   ]
 }

--- a/Makefile
+++ b/Makefile
@@ -1,33 +1,25 @@
 UNAME_S := $(shell uname -s)
-CXX_NAME := $(notdir $(lastword $(CXX)))
 
 CMAKE_ARGS ?=
-LLVM_COV ?= $(shell command -v llvm-cov 2>/dev/null || command -v llvm-cov-18 2>/dev/null || command -v llvm-cov-17 2>/dev/null || command -v llvm-cov-16 2>/dev/null || true)
 
 COLOR_CYAN := \033[36m
 COLOR_RESET := \033[0m
-CONAN_PRESETS := ConanPresets.json
 
-LLVM_BIN :=
-GCOV_TOOL := gcov
-GCOV_EXECUTABLE := gcov
+GCOV_EXECUTABLE_Linux := gcov
+GCOV_EXECUTABLE_Darwin := xcrun llvm-cov gcov
 
 ifeq ($(UNAME_S),Darwin)
-LLVM_PREFIX ?= $(shell brew --prefix llvm 2>/dev/null || true)
-LLVM_BIN := $(if $(wildcard $(LLVM_PREFIX)/bin/clang-format),$(LLVM_PREFIX)/bin,)
-ifneq ($(findstring clang,$(CXX_NAME)),)
-GCOV_TOOL := xcrun
-GCOV_EXECUTABLE := xcrun llvm-cov gcov
-endif
-else
-ifneq ($(findstring clang,$(CXX_NAME)),)
-GCOV_TOOL := $(if $(LLVM_COV),$(LLVM_COV),llvm-cov)
-GCOV_EXECUTABLE := $(GCOV_TOOL) gcov
+HOMEBREW_LLVM_PREFIX := $(shell brew --prefix llvm 2>/dev/null)
+ifneq ($(HOMEBREW_LLVM_PREFIX),)
+export PATH := $(HOMEBREW_LLVM_PREFIX)/bin:$(PATH)
 endif
 endif
 
-CLANG_FORMAT ?= $(if $(LLVM_BIN),$(LLVM_BIN)/clang-format,clang-format)
-CLANG_TIDY ?= $(if $(LLVM_BIN),$(LLVM_BIN)/clang-tidy,clang-tidy)
+GCOV_EXECUTABLE ?= $(GCOV_EXECUTABLE_$(UNAME_S))
+
+ifeq ($(GCOV_EXECUTABLE),)
+$(error unsupported host OS '$(UNAME_S)'; set GCOV_EXECUTABLE='<cmd>' to override)
+endif
 
 .DEFAULT_GOAL := help
 
@@ -37,24 +29,12 @@ endif
 
 .SECONDEXPANSION:
 
-define bootstrap-check
-@if [ ! -f $(CONAN_PRESETS) ]; then \
-	echo "error: $(CONAN_PRESETS) missing. Run 'make bootstrap' first." >&2; \
-	exit 1; \
-fi
-endef
-
 # ---------------------------------------------------------------------------
 # Conan configuration — release gets its own profile state, coverage reuses the
 # debug toolchain, and sanitize uses a dedicated Conan profile so dependency
 # binaries are rebuilt with matching instrumentation.
 # ---------------------------------------------------------------------------
-CONAN_STD := -s compiler.cppstd=23
 CONAN_PROFILE ?= profiles/default
-CONAN_INSTALL_ARGS := $(CONAN_STD) --build=missing --lockfile=conan.lock
-
-CONAN_BUILD_TYPE_debug   := Debug
-CONAN_BUILD_TYPE_release := Release
 CONAN_STAMP_debug := debug
 CONAN_STAMP_release := release
 CONAN_STAMP_sanitize := sanitize
@@ -65,8 +45,8 @@ CONAN_STAMP_coverage := debug
 # ---------------------------------------------------------------------------
 STAMP_DIR := build/.stamps
 COVERAGE_DIR := build/coverage
-FORMAT_FILES = $(shell find include src tests -type f \( -name '*.hpp' -o -name '*.cpp' \))
-TIDY_SOURCES := $(shell find src tests -type f -name '*.cpp')
+FORMAT_SOURCES = $(shell find include src tests -type f \( -name '*.hpp' -o -name '*.cpp' \))
+TIDY_SOURCES = $(shell find src tests -type f -name '*.cpp')
 
 define require-tool
 	command -v $(1) >/dev/null || { echo "$(1) not found"; exit 1; }
@@ -77,21 +57,23 @@ endef
 # ---------------------------------------------------------------------------
 conan.lock: conanfile.py $(CONAN_PROFILE)
 	echo "Regenerating conan.lock..."
-	conan lock create . $(CONAN_STD) -pr=$(CONAN_PROFILE) --lockfile-out=conan.lock
+	conan lock create . -s compiler.cppstd=23 -pr=$(CONAN_PROFILE) --lockfile-out=conan.lock
 
 # ---------------------------------------------------------------------------
 # Conan install
 # ---------------------------------------------------------------------------
-$(STAMP_DIR)/%.stamp: conan.lock
-	echo "Installing Conan dependencies ($*)..."
+$(STAMP_DIR)/debug.stamp: BUILD_TYPE = Debug
+$(STAMP_DIR)/release.stamp: BUILD_TYPE = Release
+$(STAMP_DIR)/debug.stamp $(STAMP_DIR)/release.stamp: conan.lock
+	echo "Installing Conan dependencies ($(BUILD_TYPE))..."
 	mkdir -p $(STAMP_DIR)
-	conan install . -pr=$(CONAN_PROFILE) -s build_type=$(CONAN_BUILD_TYPE_$*) $(CONAN_INSTALL_ARGS)
+	conan install . -pr=$(CONAN_PROFILE) -s compiler.cppstd=23 -s build_type=$(BUILD_TYPE) --build=missing --lockfile=conan.lock
 	touch $@
 
 $(STAMP_DIR)/sanitize.stamp: conan.lock
 	echo "Installing Conan dependencies (sanitize)..."
 	mkdir -p $(STAMP_DIR)
-	conan install . -pr=profiles/sanitize $(CONAN_INSTALL_ARGS)
+	conan install . -pr=profiles/sanitize -s compiler.cppstd=23 --build=missing --lockfile=conan.lock
 	touch $@
 
 # ---------------------------------------------------------------------------
@@ -101,43 +83,43 @@ $(STAMP_DIR)/sanitize.stamp: conan.lock
 help: ## Show this help message
 	@awk 'BEGIN {FS = ":.*##"; printf "Usage: make [options] $(COLOR_CYAN)[target] ...$(COLOR_RESET)\n\n"} \
 	/^[a-zA-Z_-]+:.*##/ {printf "  $(COLOR_CYAN)%-16s$(COLOR_RESET) %s\n", $$1, $$2}' \
-	$(MAKEFILE_LIST)
+		$(MAKEFILE_LIST)
 
 .PHONY: bootstrap
-bootstrap: $(STAMP_DIR)/debug.stamp $(STAMP_DIR)/release.stamp $(STAMP_DIR)/sanitize.stamp ## Install Conan dependencies for all presets
+bootstrap: $(STAMP_DIR)/debug.stamp $(STAMP_DIR)/release.stamp ## Install Conan dependencies for debug+release
+.PHONY: bootstrap-sanitize
+bootstrap-sanitize: $(STAMP_DIR)/sanitize.stamp ## Install sanitizer-instrumented Conan dependencies
 
 # ---------------------------------------------------------------------------
 # Build + test via workflow presets
 # ---------------------------------------------------------------------------
-.PHONY: debug release sanitize coverage
-debug:    ## Build via the debug workflow preset
-release:  ## Build and test via the release workflow preset
+.PHONY: debug
+debug: ## Build and test via the debug workflow preset
+
+.PHONY: release
+release: ## Build and test via the release workflow preset
+
+.PHONY: sanitize
 sanitize: ## Build and test via the sanitize workflow preset
-coverage: ## Build, test, and generate gcovr coverage report
 
-debug: $(STAMP_DIR)/debug.stamp
-	$(call bootstrap-check)
-	cmake --preset debug $(CMAKE_ARGS)
-	cmake --build --preset debug
+.PHONY: coverage
+coverage: coverage-data-clean ## Build and test via the coverage workflow preset
 
-release sanitize: %: $(STAMP_DIR)/$$(CONAN_STAMP_%).stamp
-	$(call bootstrap-check)
+debug release sanitize coverage: %: $(STAMP_DIR)/$$(CONAN_STAMP_%).stamp
 	cmake --preset $@ $(CMAKE_ARGS)
 	cmake --build --preset $@
 	ctest --preset $@
 
 # ---------------------------------------------------------------------------
-# Coverage report generation (appended after the workflow runs tests)
+# Coverage report generation
 # ---------------------------------------------------------------------------
-coverage: $(STAMP_DIR)/$$(CONAN_STAMP_coverage).stamp
-	$(call bootstrap-check)
-	rm -rf $(COVERAGE_DIR)
-	mkdir -p $(COVERAGE_DIR)
-	cmake --preset coverage $(CMAKE_ARGS)
-	cmake --build --preset coverage
-	ctest --preset coverage
+.PHONY: coverage-data-clean
+coverage-data-clean:
+	-find $(COVERAGE_DIR) -name '*.gcda' -delete
+
+.PHONY: coverage-report
+coverage-report: coverage ## Generate gcovr coverage report after running coverage
 	$(call require-tool,python3)
-	$(call require-tool,$(GCOV_TOOL))
 	mkdir -p $(COVERAGE_DIR)/coverage-report
 	python3 -m gcovr --root . \
 		--gcov-executable "$(GCOV_EXECUTABLE)" \
@@ -152,24 +134,22 @@ coverage: $(STAMP_DIR)/$$(CONAN_STAMP_coverage).stamp
 # Lint and format
 # ---------------------------------------------------------------------------
 .PHONY: lint
-lint: ## Run clang-tidy against the debug compilation database
-	$(call bootstrap-check)
-	$(call require-tool,$(CLANG_TIDY))
+lint: $(STAMP_DIR)/debug.stamp ## Run clang-tidy against the debug compilation database
+	$(call require-tool,clang-tidy)
 	cmake --preset debug $(CMAKE_ARGS)
-	$(CLANG_TIDY) -p build/debug $(TIDY_SOURCES)
+	PATH="$(PATH)" clang-tidy -p build/debug $(TIDY_SOURCES)
 
 .PHONY: format
 format: ## Format C++ sources in place with clang-format
 	echo "Formatting C++ sources..."
-	$(call require-tool,$(CLANG_FORMAT))
-	$(CLANG_FORMAT) -i $(FORMAT_FILES)
+	$(call require-tool,clang-format)
+	PATH="$(PATH)" clang-format -i $(FORMAT_SOURCES)
 
 .PHONY: format-check
 format-check: ## Fail if C++ sources are not clang-format clean
-	$(call bootstrap-check)
 	echo "Checking C++ formatting..."
-	$(call require-tool,$(CLANG_FORMAT))
-	$(CLANG_FORMAT) --dry-run --Werror $(FORMAT_FILES)
+	$(call require-tool,clang-format)
+	PATH="$(PATH)" clang-format --dry-run --Werror $(FORMAT_SOURCES)
 
 # ---------------------------------------------------------------------------
 # Lock and clean
@@ -180,4 +160,4 @@ lock: conan.lock ## Ensure conan.lock is up to date
 .PHONY: clean
 clean: ## Remove generated build artifacts and Conan preset files
 	echo "Removing generated artifacts..."
-	rm -rf build/ ConanPresets.json compile_commands.json CMakeUserPresets.json
+	rm -rf build/ compile_commands.json CMakeUserPresets.json ConanPresets.json

--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@ dependency management, CMake presets, testing, sanitizers, coverage, CI, and IDE
 
 This repository uses:
 
-- [CMake](https://cmake.org) presets and workflow presets as the public build interface
+- [CMake](https://cmake.org) configure, build, and test presets as the public build interface
 - [Conan 2](https://conan.io) for dependency management
 - [spdlog](https://github.com/gabime/spdlog) via Conan as the sample compiled dependency
 - [GoogleTest](https://github.com/google/googletest) via Conan
 
 The checked-in presets are the source of truth. [`Makefile`](Makefile) is a thin convenience
-wrapper around `make bootstrap` plus the public CMake presets and workflows.
+wrapper around `make bootstrap` plus the public CMake presets.
 
 ## Prerequisites
 
@@ -74,6 +74,9 @@ make sanitize
 This uses a dedicated sanitizer build tree under `build/sanitize` and a Conan
 sanitize profile so dependencies are rebuilt with matching instrumentation.
 
+The default `make bootstrap` does not install sanitizer-instrumented dependencies. Run
+`make bootstrap-sanitize` or `make sanitize` when you need them.
+
 > [!NOTE]
 > Conan owns the dependency graph, generator, toolchain, and ABI settings. If you switch the Conan
 > configuration, rerun `make bootstrap` or the matching public `make` target and keep using the
@@ -82,15 +85,14 @@ sanitize profile so dependencies are rebuilt with matching instrumentation.
 ### Tests
 
 Tests are controlled by CMake's built-in `BUILD_TESTING` option from `include(CTest)`. This
-project leaves it at the default `ON`, so the `release`, `sanitize`, and `coverage` workflows run the
-test suite by default.
+project leaves it at the default `ON`, so `make debug`, `make release`, `make sanitize`, and
+`make coverage` all run the gtest suite.
 
 ## Public presets
 
 - Configure presets: `debug`, `release`, `sanitize`, `coverage`
 - Build presets: `debug`, `release`, `sanitize`, `coverage`
 - Test presets: `debug`, `release`, `sanitize`, `coverage`
-- Workflow presets: `debug`, `release`, `sanitize`, `coverage`
 
 The Conan-generated `conan-*` presets are internal implementation details and are not the public
 interface for developers or CI.
@@ -155,4 +157,4 @@ CLion can use the same public presets. Run `make bootstrap` first, then in CLion
 - `src/`: application sources
 - `tests/`: unit tests
 - `conanfile.py`: Conan dependency definition
-- `CMakePresets.json`: project-owned public presets and workflows
+- `CMakePresets.json`: project-owned public presets

--- a/conanfile.py
+++ b/conanfile.py
@@ -24,9 +24,15 @@ class CppBoilerplateConan(ConanFile):
         return "Ninja" if shutil.which("ninja") else "Unix Makefiles"
 
     def layout(self):
+        if self.conf.get("user.project:sanitize", default=False, check_type=bool):
+            self.folders.build_folder_vars = ["const.sanitize"]
         cmake_layout(self, generator=self._cmake_generator(), build_folder="build")
         bt = str(self.settings.build_type).lower()
-        self.folders.build = f"build/{bt}"
+        if self.conf.get("user.project:sanitize", default=False, check_type=bool):
+            folder = "build/sanitize"
+        else:
+            folder = f"build/{bt}"
+        self.folders.build = folder
         self.folders.generators = f"{self.folders.build}/generators"
 
     def build_requirements(self):

--- a/profiles/sanitize
+++ b/profiles/sanitize
@@ -4,6 +4,7 @@ include(default)
 build_type=Debug
 
 [conf]
+user.project:sanitize=True
 tools.build:cflags=["-fsanitize=address,undefined", "-fno-omit-frame-pointer", "-fno-sanitize-recover=all"]
 tools.build:cxxflags=["-fsanitize=address,undefined", "-fno-omit-frame-pointer", "-fno-sanitize-recover=all"]
 tools.build:sharedlinkflags=["-fsanitize=address,undefined"]

--- a/src/split.cpp
+++ b/src/split.cpp
@@ -7,10 +7,6 @@ namespace cpp_boilerplate {
 
 std::vector<std::string_view> split_views_vec(std::string_view record, char delimiter)
 {
-    if (record.empty()) {
-        return {std::string_view{}};
-    }
-
     auto view = split_views(record, delimiter);
     return {view.begin(), view.end()};
 }

--- a/tests/split_test.cpp
+++ b/tests/split_test.cpp
@@ -11,9 +11,9 @@ TEST(SplitTest, SplitsCommaSeparatedFields)
     EXPECT_EQ(cpp_boilerplate::split_views_vec("52930489,aaa,18,1222"), expected);
 }
 
-TEST(SplitTest, ReturnsSingleEmptyFieldForEmptyInput)
+TEST(SplitTest, ReturnsEmptySequenceForEmptyInput)
 {
-    const std::vector<std::string_view> expected{""};
+    const std::vector<std::string_view> expected{};
     EXPECT_EQ(cpp_boilerplate::split_views_vec(""), expected);
 }
 


### PR DESCRIPTION
## Summary
- isolate sanitize Conan output from debug and stabilize sanitize preset generation
- make sanitize dependency installs opt-in, remove dead workflow presets, and run tests in make debug
- align empty split semantics and simplify the Makefile and coverage/tooling flow

## Verification
- make debug
- make coverage-report
- make lint
- make format-check