### PR TITLE
build: instrument sanitizer dependencies via custom package_id

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,8 +31,9 @@ endif
 
 # ---------------------------------------------------------------------------
 # Conan configuration — release gets its own profile state, coverage reuses the
-# debug toolchain, and sanitize uses a dedicated Conan profile so dependency
-# binaries are rebuilt with matching instrumentation.
+# debug toolchain, and sanitize uses a dedicated Conan profile plus a custom
+# compiler.sanitizer setting (conan/settings_user.yml) so instrumented dependency
+# binaries get a distinct package_id and are rebuilt rather than reused from cache.
 # ---------------------------------------------------------------------------
 CONAN_PROFILE ?= profiles/default
 CONAN_STAMP_debug := debug
@@ -70,9 +71,10 @@ $(STAMP_DIR)/debug.stamp $(STAMP_DIR)/release.stamp: conan.lock
 	conan install . -pr=$(CONAN_PROFILE) -s compiler.cppstd=23 -s build_type=$(BUILD_TYPE) --build=missing --lockfile=conan.lock
 	touch $@
 
-$(STAMP_DIR)/sanitize.stamp: conan.lock
+$(STAMP_DIR)/sanitize.stamp: conan.lock conan/settings_user.yml
 	echo "Installing Conan dependencies (sanitize)..."
 	mkdir -p $(STAMP_DIR)
+	conan config install conan
 	conan install . -pr=profiles/sanitize -s compiler.cppstd=23 --build=missing --lockfile=conan.lock
 	touch $@
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,20 @@ make sanitize
 ```
 
 This uses a dedicated sanitizer build tree under `build/sanitize` and a Conan
-sanitize profile so dependencies are rebuilt with matching instrumentation.
+sanitize profile so dependencies are rebuilt with matching instrumentation, not
+linked from their plain (uninstrumented) Debug binaries.
+
+That separation relies on a custom `compiler.sanitizer` setting defined in
+[`conan/settings_user.yml`](conan/settings_user.yml). The setting gives instrumented
+dependency binaries a distinct Conan `package_id`; the sanitizer flags themselves
+travel through the profile's `tools.build:*` conf, which does not affect `package_id`.
+Without the setting, `--build=missing` would silently reuse the uninstrumented Debug
+binaries.
+
+`make bootstrap-sanitize` installs that file into your Conan home with
+`conan config install conan` before resolving dependencies. This is a global Conan
+side effect: it adds the `compiler.sanitizer` subsetting (default `null`, omitted from
+`package_id`) and does not change non-sanitize builds.
 
 The default `make bootstrap` does not install sanitizer-instrumented dependencies. Run
 `make bootstrap-sanitize` or `make sanitize` when you need them.
@@ -157,4 +170,6 @@ CLion can use the same public presets. Run `make bootstrap` first, then in CLion
 - `src/`: application sources
 - `tests/`: unit tests
 - `conanfile.py`: Conan dependency definition
+- `conan/settings_user.yml`: custom `compiler.sanitizer` setting for instrumented dependency builds
+- `profiles/`: Conan profiles (`default`, `sanitize`)
 - `CMakePresets.json`: project-owned public presets

--- a/conan/settings_user.yml
+++ b/conan/settings_user.yml
@@ -1,0 +1,17 @@
+# Custom Conan settings merged into the built-in model via `conan config install`.
+#
+# `compiler.sanitizer` exists so that sanitizer-instrumented dependency binaries
+# get a distinct package_id from their plain counterparts. Without it, the
+# sanitizer flags travel only through `tools.build:*` conf, which does not enter
+# package_id, so `--build=missing` would reuse uninstrumented cached binaries.
+#
+# The value only separates package_id; the actual flags are injected by
+# profiles/sanitize. `null` is the default (no sanitizer) and is omitted from
+# package_id, so non-sanitize builds are unaffected.
+compiler:
+    apple-clang:
+        sanitizer: [null, Address, Undefined, AddressUndefined]
+    clang:
+        sanitizer: [null, Address, Undefined, AddressUndefined]
+    gcc:
+        sanitizer: [null, Address, Undefined, AddressUndefined]

--- a/profiles/sanitize
+++ b/profiles/sanitize
@@ -2,6 +2,10 @@ include(default)
 
 [settings]
 build_type=Debug
+# Distinct package_id for instrumented dependency binaries. The flags below do the
+# actual instrumentation; this setting only keeps them from sharing a plain-Debug
+# package_id. Requires conan/settings_user.yml (installed by `make bootstrap-sanitize`).
+compiler.sanitizer=AddressUndefined
 
 [conf]
 user.project:sanitize=True


### PR DESCRIPTION
Resolves review finding #1: sanitizer builds linked **uninstrumented** dependency binaries.

## Problem

`profiles/sanitize` injected `-fsanitize=address,undefined` only through `tools.build:cflags`/`cxxflags` conf. Conan 2 does **not** fold `conf` into `package_id`, so the instrumented and plain-Debug variants of `spdlog`/`fmt`/`gtest` shared a `package_id`. Because `make bootstrap` populates the Debug binaries first, `make bootstrap-sanitize`'s `--build=missing` resolved to those cached **uninstrumented** binaries. The outcome was also cache-order dependent. This contradicted the README ("dependencies are rebuilt with matching instrumentation") and the Makefile comment.

## Fix

Make the instrumentation enter `package_id` so Conan treats it as a distinct binary:

- **`conan/settings_user.yml`** — adds a custom `compiler.sanitizer` subsetting (`null`, `Address`, `Undefined`, `AddressUndefined`) for gcc/clang/apple-clang. `null` is the default and is omitted from `package_id`.
- **`profiles/sanitize`** — sets `compiler.sanitizer=AddressUndefined`. The existing `tools.build:*` conf still performs the actual instrumentation; the setting only separates the `package_id`.
- **`Makefile`** — `bootstrap-sanitize` runs `conan config install conan` to merge the setting into the Conan home before resolving deps, and the sanitize stamp now depends on `conan/settings_user.yml`.
- Docs updated (README, Makefile comment) to describe the mechanism and the global Conan side effect.

## Verification

- Instrumented `spdlog` (`46b20430…`) carries **1591** ASan symbol references; the plain-Debug `spdlog` (`991b29ad…`) carries **0**.
- Package IDs diverge once the setting is applied (`spdlog 46b20430` vs `991b29ad`, `fmt 1e4bfe4e` vs `025a4a68`), and `--build=missing` rebuilds them.
- With the setting **unset**, default/debug/release package IDs are byte-identical to before, so non-sanitize builds and `conan.lock` are unaffected.
- `make sanitize` builds and passes 6/6 tests under ASan+UBSan with the instrumented deps linked.

## Notes / trade-offs

- `make bootstrap-sanitize` mutates the user's Conan home (adds the `compiler.sanitizer` subsetting). This is the documented Conan 2 mechanism for custom settings; it is additive and does not affect other projects. Documented in the README.
- No CI changes required: the sanitize job already runs `make bootstrap-sanitize`, which now performs the `conan config install`.
- `conan.lock` is unchanged (it pins versions/revisions, not package IDs).

Independent of #14 (the #5 cleanups); branched from `main`. Follow-ups still open: #2 (sanitizer flags double-specified — partly mooted here since deps now genuinely need the conf flags), #3 (dead `build_folder_vars` / hand-rolled `layout()`), #4 (coverage preset's implicit Debug-toolchain coupling).