### PR TITLE
build: fix make help column alignment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ $(STAMP_DIR)/sanitize.stamp: conan.lock conan/settings_user.yml
 .PHONY: help
 help: ## Show this help message
 	@awk 'BEGIN {FS = ":.*##"; printf "Usage: make [options] $(COLOR_CYAN)[target] ...$(COLOR_RESET)\n\n"} \
-	/^[a-zA-Z_-]+:.*##/ {printf "  $(COLOR_CYAN)%-16s$(COLOR_RESET) %s\n", $$1, $$2}' \
+	/^[a-zA-Z_-]+:.*##/ {printf "  $(COLOR_CYAN)%-20s$(COLOR_RESET) %s\n", $$1, $$2}' \
 		$(MAKEFILE_LIST)
 
 .PHONY: bootstrap


### PR DESCRIPTION
`make help` padded target names to `%-16s`, but `bootstrap-sanitize` (18 chars, added in #15) overflowed that width, pushing its description out of the shared column. Widen the `printf` field to `%-20s` to clear the longest name.

## Before
```
  bootstrap           Install Conan dependencies for debug+release
  bootstrap-sanitize  Install sanitizer-instrumented Conan dependencies
  debug               Build and test via the debug workflow preset
```

## After
```
  bootstrap             Install Conan dependencies for debug+release
  bootstrap-sanitize    Install sanitizer-instrumented Conan dependencies
  debug                 Build and test via the debug workflow preset
```

Cosmetic only; no target behavior changes.