### PR TITLE
build: let Conan own the build layout; single-source sanitizer flags

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -13,34 +13,25 @@
       "name": "debug",
       "displayName": "Debug",
       "description": "Debug configuration backed by Conan's debug preset.",
-      "inherits": "conan-debug",
-      "binaryDir": "${sourceDir}/build/debug",
-      "toolchainFile": "${sourceDir}/build/debug/generators/conan_toolchain.cmake"
+      "inherits": "conan-debug"
     },
     {
       "name": "release",
       "displayName": "Release",
       "description": "Release configuration backed by Conan's release preset.",
-      "inherits": "conan-release",
-      "binaryDir": "${sourceDir}/build/release",
-      "toolchainFile": "${sourceDir}/build/release/generators/conan_toolchain.cmake"
+      "inherits": "conan-release"
     },
     {
       "name": "sanitize",
       "displayName": "Sanitizers",
-      "description": "Debug configuration with sanitizer instrumentation enabled.",
-      "inherits": "conan-sanitize-debug",
-      "binaryDir": "${sourceDir}/build/sanitize",
-      "toolchainFile": "${sourceDir}/build/sanitize/generators/conan_toolchain.cmake",
-      "cacheVariables": {
-        "ENABLE_SANITIZERS": "ON"
-      }
+      "description": "Debug configuration with sanitizer instrumentation from the Conan sanitize profile.",
+      "inherits": "conan-debug-addressundefined"
     },
     {
       "name": "coverage",
       "displayName": "Coverage",
-      "description": "Debug configuration with coverage instrumentation enabled.",
-      "inherits": "conan-debug",
+      "description": "Debug configuration with coverage instrumentation enabled. Reuses the debug toolchain.",
+      "inherits": "debug",
       "binaryDir": "${sourceDir}/build/coverage",
       "toolchainFile": "${sourceDir}/build/debug/generators/conan_toolchain.cmake",
       "cacheVariables": {

--- a/Makefile
+++ b/Makefile
@@ -31,9 +31,10 @@ endif
 
 # ---------------------------------------------------------------------------
 # Conan configuration — release gets its own profile state, coverage reuses the
-# debug toolchain, and sanitize uses a dedicated Conan profile plus a custom
-# compiler.sanitizer setting (conan/settings_user.yml) so instrumented dependency
-# binaries get a distinct package_id and are rebuilt rather than reused from cache.
+# debug toolchain (its dependency graph is identical to Debug), and sanitize uses
+# a dedicated profile plus a custom compiler.sanitizer setting (conan/settings_user.yml)
+# so instrumented dependency binaries get a distinct package_id and are rebuilt
+# rather than reused from cache.
 # ---------------------------------------------------------------------------
 CONAN_PROFILE ?= profiles/default
 CONAN_STAMP_debug := debug

--- a/README.md
+++ b/README.md
@@ -71,9 +71,10 @@ the one-time per-clone step that materializes it.
 make sanitize
 ```
 
-This uses a dedicated sanitizer build tree under `build/sanitize` and a Conan
-sanitize profile so dependencies are rebuilt with matching instrumentation, not
-linked from their plain (uninstrumented) Debug binaries.
+This uses a dedicated sanitizer build tree (Conan names it `build/debug-addressundefined`
+after the build type and `compiler.sanitizer` setting) and a Conan sanitize profile so
+dependencies are rebuilt with matching instrumentation, not linked from their plain
+(uninstrumented) Debug binaries.
 
 That separation relies on a custom `compiler.sanitizer` setting defined in
 [`conan/settings_user.yml`](conan/settings_user.yml). The setting gives instrumented
@@ -89,6 +90,13 @@ side effect: it adds the `compiler.sanitizer` subsetting (default `null`, omitte
 
 The default `make bootstrap` does not install sanitizer-instrumented dependencies. Run
 `make bootstrap-sanitize` or `make sanitize` when you need them.
+
+First-party targets are instrumented by the same Conan toolchain (the profile's
+`tools.build:*` flags reach the consumer), so the `sanitize` preset does not also set
+the CMake `ENABLE_SANITIZERS` option, which would double the flags. `ENABLE_SANITIZERS`
+remains a standalone option for instrumenting first-party code without the Conan
+profile, e.g. `cmake --preset debug -DENABLE_SANITIZERS=ON` (dependencies stay
+uninstrumented in that mode).
 
 > [!NOTE]
 > Conan owns the dependency graph, generator, toolchain, and ABI settings. If you switch the Conan

--- a/conanfile.py
+++ b/conanfile.py
@@ -24,19 +24,14 @@ class CppBoilerplateConan(ConanFile):
         return "Ninja" if shutil.which("ninja") else "Unix Makefiles"
 
     def layout(self):
-        # The sanitize build shares Debug settings and is distinguished only by the
-        # compiler.sanitizer setting (see conan/settings_user.yml).
-        sanitize = bool(self.settings.get_safe("compiler.sanitizer"))
-        if sanitize:
-            # Names the generated Conan preset conan-sanitize-debug, which the
-            # checked-in CMakePresets sanitize preset inherits.
-            self.folders.build_folder_vars = ["const.sanitize"]
-        cmake_layout(self, generator=self._cmake_generator(), build_folder="build")
-        # Flatten the generator output into build/<preset> so the paths line up with
-        # the checked-in CMakePresets binaryDir/toolchainFile.
-        folder = "build/sanitize" if sanitize else f"build/{str(self.settings.build_type).lower()}"
-        self.folders.build = folder
-        self.folders.generators = f"{folder}/generators"
+        # Let Conan own the build layout. build_type gives build/debug and build/release;
+        # compiler.sanitizer (see conan/settings_user.yml) splits the instrumented build
+        # into build/debug-addressundefined with its own conan-debug-addressundefined
+        # preset. An unset or undefined sanitizer is omitted, so plain Debug builds (and
+        # clones without settings_user.yml) are unaffected. Coverage is not a Conan
+        # dimension; its CMake preset reuses the debug toolchain.
+        self.folders.build_folder_vars = ["settings.build_type", "settings.compiler.sanitizer"]
+        cmake_layout(self, generator=self._cmake_generator())
 
     def build_requirements(self):
         self.test_requires("gtest/1.15.0")


### PR DESCRIPTION
Simplifies build-layout management by leaning on Conan + CMake's built-in layout, and folds in the two remaining review findings (#2, #4).

## Layout — hand off to Conan (the main change)

The custom `layout()` flattened folders to `build/<preset>` and used a `const.sanitize` trick to control the generated preset name and avoid a `conan-debug` collision. All of that is now Conan-native:

```python
def layout(self):
    self.folders.build_folder_vars = ["settings.build_type", "settings.compiler.sanitizer"]
    cmake_layout(self, generator=self._cmake_generator())
```

Verified behavior:
- `build/debug`, `build/release`, and `build/debug-addressundefined` (sanitize), each with its own generated `conan-debug` / `conan-release` / `conan-debug-addressundefined` preset.
- An **unset or undefined** `compiler.sanitizer` is omitted from the name (no collision), and referencing it in `build_folder_vars` does **not** error when `settings_user.yml` isn't installed — so plain `make bootstrap` clones are unaffected.

Because the generated `conan-*` presets already carry `binaryDir` and a relative `toolchainFile`, the checked-in presets become thin aliases:

```json
{ "name": "debug",    "inherits": "conan-debug" },
{ "name": "release",  "inherits": "conan-release" },
{ "name": "sanitize", "inherits": "conan-debug-addressundefined" },
{ "name": "coverage", "inherits": "debug",
  "binaryDir": "${sourceDir}/build/coverage",
  "toolchainFile": "${sourceDir}/build/debug/generators/conan_toolchain.cmake",
  "cacheVariables": { "ENABLE_COVERAGE": "ON" } }
```

No hand-written paths except coverage's explicit pin to the debug toolchain (a relative toolchainFile can't follow coverage's overridden binary dir, and coverage reusing the debug deps is the honest design). **Public `make` targets and preset names are unchanged.**

Tradeoff: the sanitize *build folder* is now `build/debug-addressundefined` and the inherited Conan preset is `conan-debug-addressundefined`, rather than the prettier `build/sanitize`. Both are gitignored; the prettier names would require keeping the `const.sanitize` conditional we're deleting. README's one `build/sanitize` mention is updated.

## #2 — Sanitizer flags had two owners

The `sanitize` preset set `ENABLE_SANITIZERS=ON` while the Conan profile's `tools.build:*` flags already reach the consumer through the toolchain, so first-party objects got `-fsanitize` twice. `*:tools.build:cxxflags` still injects into the consumer (Conan's `*` matches the consumer; no deps-only pattern), so the toolchain necessarily instruments first-party code. Dropped `ENABLE_SANITIZERS=ON` from the preset; the toolchain is the single owner. The CMake option stays for standalone first-party instrumentation (`cmake --preset debug -DENABLE_SANITIZERS=ON`).

## #4 — Coverage is a CMake-only variant

Coverage's dependency graph is identical to Debug, so its preset inherits `debug` and pins the debug toolchain — no coverage-specific Conan install or generators.

## Verification (from `make clean`)

- `make debug` works with only debug/release installed (the `sanitize` preset inheriting a not-yet-present `conan-debug-addressundefined` does not block it).
- `debug`, `release`, `sanitize`, `coverage` all build and pass 6/6.
- Sanitize first-party objects carry **one** `-fsanitize`; coverage builds into `build/coverage` off the debug toolchain and `make coverage-report` still emits the xml + HTML.
- `format-check` clean; no stale `const.sanitize` / `build/sanitize` / `conan-sanitize-debug` references.

Clears all findings from the original review (#1–#5) plus the layout simplification.