### PR TITLE
build: correct Conan floor (2.25+); least-privilege CI token; cleanups

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: ${{ matrix.preset }} / ${{ matrix.os }} / ${{ matrix.compiler }}

--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ $(STAMP_DIR)/sanitize.stamp: conan.lock conan/settings_user.yml
 	echo "Installing Conan dependencies (sanitize)..."
 	mkdir -p $(STAMP_DIR)
 	conan config install conan
-	conan install . -pr=profiles/sanitize -s compiler.cppstd=23 --build=missing --lockfile=conan.lock
+	conan install . -pr=profiles/sanitize --build=missing --lockfile=conan.lock
 	touch $@
 
 # ---------------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ## Overview
 
-A modern C++23 project template demonstrating end-to-end toolchain integration: Conan 2.5+
+A modern C++23 project template demonstrating end-to-end toolchain integration: Conan 2.25+
 dependency management, CMake presets, testing, sanitizers, coverage, CI, and IDE setup.
 
 This repository uses:
@@ -23,13 +23,13 @@ wrapper around `make bootstrap` plus the public CMake presets.
 
 ## Prerequisites
 
-- CMake 3.28+
-- Conan 2.5+
-- Ninja or GNU Make on Unix-like systems
+- [CMake](https://cmake.org/download/) 3.28+
+- [Conan](https://docs.conan.io/2/installation.html) 2.25+ (for the `CMakeConfigDeps` generator)
+- [Ninja](https://ninja-build.org/) or GNU Make on Unix-like systems
 - A compiler and standard library with working C++23 support
-  - GCC 13+
-  - LLVM Clang 17+
-  - Apple Clang 17+ recommended
+  - [GCC](https://gcc.gnu.org/) 13+
+  - [LLVM Clang](https://llvm.org/) 17+
+  - [Apple Clang](https://developer.apple.com/xcode/) 17+ recommended
 
 Conan chooses the CMake generator for you:
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -5,7 +5,7 @@ from conan.tools.cmake import CMakeConfigDeps, CMakeToolchain, cmake_layout
 
 
 class CppBoilerplateConan(ConanFile):
-    required_conan_version = ">=2.5"
+    required_conan_version = ">=2.25"  # CMakeConfigDeps is available from 2.25
     name = "cpp-boilerplate"
     version = "0.1.0"
     package_type = "application"
@@ -42,8 +42,10 @@ class CppBoilerplateConan(ConanFile):
         self.test_requires("gtest/1.15.0")
 
     def generate(self):
-        # CMakeConfigDeps (Conan 2.x) generates CMake CONFIG find_package files under
-        # the build dir. Preferred over the legacy CMakeDeps generator.
+        # CMakeConfigDeps generates CMake CONFIG-mode find_package files under the build
+        # dir. It is experimental in Conan 2.x (it prints a warning and its behavior may
+        # change); we use it to exercise the modern generator. Switch to the stable
+        # CMakeDeps if you need a settled interface.
         deps = CMakeConfigDeps(self)
         deps.generate()
 


### PR DESCRIPTION
A small batch of best-practice/correctness fixes for the public boilerplate. Independent of #18 (different files/hunks).

## Changes

- **Correct the Conan version floor to `>=2.25`.** The recipe imports `CMakeConfigDeps`, which Conan's docs list as available (experimental) only **from 2.25** — before that it existed only as an incubating generator behind a conf flag, not as `from conan.tools.cmake import CMakeConfigDeps`. The previous `>=2.5` understated the requirement and would fail to import on 2.5–2.24. Updated `required_conan_version` and the two `Conan 2.5+` mentions in the README.
- **Fix the `generate()` comment** — `CMakeConfigDeps` is *experimental* in Conan 2.x (it prints a warning and may change), not "preferred over the legacy CMakeDeps." `CMakeDeps` is the stable generator. (Kept `CMakeConfigDeps` to exercise the modern path, per the chosen direction.)
- **CI least-privilege token** — declare `permissions: contents: read` at the workflow level. The jobs only read the repo and upload artifacts; neither needs write scope (OpenSSF Token-Permissions posture).
- **Drop redundant `-s compiler.cppstd=23`** from the sanitize Conan install. `profiles/sanitize` already pins `cppstd=23` via `include(default)`.
- **Add install links** to the Prerequisites section (CMake, Conan, Ninja, GCC, LLVM Clang, Apple Clang) so a fresh clone can find the tools. GNU Make is left unlinked (ships everywhere).

## Verification

Recipe loads under the new floor (local Conan 2.29); `debug`, `release`, `sanitize`, `coverage` all build and pass 6/6; the gcovr coverage report still generates. Conan install link verified live; Prerequisites lines stay within the 100-col limit.

## Considered and deliberately left out

A **CMake library target** (compile `src/split.cpp` once, link it from app + tests) is the textbook layout, but it breaks this project's gcov-based coverage: with a static library, AppleClang writes `split.cpp`'s `.gcda` under the consuming test target's directory while the `.gcno` stays under the library's directory, so gcov can't pair them and the macOS/clang coverage CI job would fail. Fixing it cleanly across GCC/Clang/AppleClang needs toolchain-conditional coverage plumbing — added complexity that works against the simplification goal. Left out for now; happy to revisit if we want to invest in the coverage tooling.