### PR TITLE
ci: enforce a coverage floor and actually generate the report

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        preset: [release, sanitize, coverage]
+        preset: [release, sanitize]
         compiler: [gcc, clang]
         exclude:
           - os: macos-latest
@@ -43,16 +43,33 @@ jobs:
         run: |
           conan lock create . -pr=profiles/default --lockfile-out=/tmp/fresh.lock
           diff conan.lock /tmp/fresh.lock
-      - if: matrix.preset == 'coverage'
-        run: python3 -m pip install --break-system-packages --user gcovr
       - run: make bootstrap
       - if: matrix.preset == 'sanitize'
         run: make bootstrap-sanitize
       - run: make ${{ matrix.preset }}
-      - if: matrix.preset == 'coverage'
-        uses: actions/upload-artifact@v4
+
+  coverage:
+    name: coverage / ubuntu-latest / gcc
+    runs-on: ubuntu-latest
+    env:
+      CC: gcc
+      CXX: g++
+      CMAKE_ARGS: -DWARNINGS_AS_ERRORS=ON
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v4
         with:
-          name: coverage-${{ matrix.os }}-${{ matrix.compiler }}
+          path: ~/.conan2
+          key: conan-ubuntu-latest-gcc-${{ hashFiles('conanfile.py', 'conan.lock') }}
+          restore-keys: conan-ubuntu-latest-gcc-
+      - uses: conan-io/setup-conan@v1
+      - run: python3 -m pip install --break-system-packages --user gcovr
+      - run: make bootstrap
+      # Builds, runs the suite, and fails if line coverage drops below the floor.
+      - run: make coverage-report
+      - uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
           path: build/coverage/coverage-report/
 
   lint:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,4 +84,10 @@ if(BUILD_TESTING)
     enable_sanitizers(split_test)
     enable_coverage(split_test)
     gtest_discover_tests(split_test DISCOVERY_MODE PRE_TEST)
+
+    # Smoke test: the application binary runs to completion and exits cleanly.
+    # Complements the unit tests by exercising src/main.cpp, including under the
+    # sanitizer and coverage presets.
+    add_test(NAME AppTest.RunsToCompletion COMMAND cpp_boilerplate)
+    set_tests_properties(AppTest.RunsToCompletion PROPERTIES PASS_REGULAR_EXPRESSION "done")
 endif()

--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,7 @@ CONAN_STAMP_coverage := debug
 # ---------------------------------------------------------------------------
 STAMP_DIR := build/.stamps
 COVERAGE_DIR := build/coverage
+COVERAGE_FAIL_UNDER ?= 70
 FORMAT_SOURCES = $(shell find include src tests -type f \( -name '*.hpp' -o -name '*.cpp' \))
 TIDY_SOURCES = $(shell find src tests -type f -name '*.cpp')
 
@@ -131,6 +132,7 @@ coverage-report: coverage ## Generate gcovr coverage report after running covera
 		--html-details $(COVERAGE_DIR)/coverage-report/index.html \
 		--cobertura $(COVERAGE_DIR)/coverage.xml \
 		--txt-summary \
+		--fail-under-line $(COVERAGE_FAIL_UNDER) \
 		$(COVERAGE_DIR)
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Adds the coverage floor requested in #20. **Stacked on #20** (base `test/app-smoke-coverage`); rebase to `main` once #20 merges.

## The floor

`COVERAGE_FAIL_UNDER` (default **70**, overridable) is passed to gcovr as `--fail-under-line`, so `make coverage-report` exits non-zero when line coverage drops below the floor:

```make
make coverage-report                      # fails under 70% line coverage
make coverage-report COVERAGE_FAIL_UNDER=80
```

## Fixing CI while wiring it in

The coverage CI was a no-op: it ran `make coverage` (build + test only) and uploaded `build/coverage/coverage-report/`, but that directory is produced by `make coverage-report`, which **never ran in CI**. gcovr was pip-installed and never invoked; the artifact was empty. This now runs `make coverage-report`, which builds, tests, generates the HTML/Cobertura report, and enforces the floor.

## Dedicated coverage job

Coverage moves out of the build matrix into a dedicated `ubuntu-latest` / `gcc` job:

- Coverage measures which **source lines run** — compiler-independent — so one canonical measurement is enough; the previous 3-way matrix (ubuntu gcc+clang, macos clang) was redundant for coverage.
- gcc + `gcov` also avoids the clang/`llvm-cov gcov` mismatch that would break a matrix-wide report (the Makefile picks the gcov front-end by OS, not compiler).
- The build matrix keeps `release` + `sanitize` across all toolchains; only coverage changed.

## Verification (local)

- YAML parses; jobs are `build` / `coverage` / `lint`; build matrix is `[release, sanitize]`.
- Floor **passes** at the default 70 (current line coverage 76.9%).
- Floor **fires**: `make coverage-report COVERAGE_FAIL_UNDER=90` exits non-zero, confirming the gate actually fails the build rather than just being present.

## Note on the threshold

70 leaves ~7 points of headroom below the current 76.9% — loose enough to absorb minor noise, tight enough to catch a real regression (e.g. dropping the smoke test would crater it to 23%). Bump it later if you want a stricter gate.