### PR TITLE
build: library target + dual-mechanism coverage (llvm-cov and gcov)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,38 +56,63 @@ function(enable_coverage target)
         return()
     endif()
 
-    if(NOT CMAKE_CXX_COMPILER_ID MATCHES "^(GNU|Clang|AppleClang)$")
-        message(FATAL_ERROR "Coverage instrumentation requires GCC, Clang, or AppleClang")
+    if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+        # Clang and AppleClang: source-based coverage, read by llvm-cov.
+        target_compile_options(${target} PRIVATE -O0 -g -fprofile-instr-generate
+                                                 -fcoverage-mapping
+        )
+        target_link_options(${target} PRIVATE -fprofile-instr-generate)
+    elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+        # GCC: gcov-based coverage, read by gcovr.
+        target_compile_options(${target} PRIVATE -O0 -g --coverage)
+        target_link_options(${target} PRIVATE --coverage)
+    else()
+        message(FATAL_ERROR "Coverage requires GCC, Clang, or AppleClang")
     endif()
-
-    target_compile_options(${target} PRIVATE -O0 -g --coverage)
-    target_link_options(${target} PRIVATE --coverage)
 endfunction()
 
-add_executable(cpp_boilerplate src/main.cpp src/split.cpp)
-target_compile_features(cpp_boilerplate PRIVATE cxx_std_23)
-target_include_directories(cpp_boilerplate PRIVATE ${PROJECT_SOURCE_DIR}/include)
-target_link_libraries(cpp_boilerplate PRIVATE spdlog::spdlog)
-enable_project_warnings(cpp_boilerplate)
-enable_sanitizers(cpp_boilerplate)
-enable_coverage(cpp_boilerplate)
+function(enable_project_options target)
+    enable_project_warnings(${target})
+    enable_sanitizers(${target})
+    enable_coverage(${target})
+endfunction()
+
+# --- library ---------------------------------------------------------------
+# Non-main code lives in a library so the application and the tests link the same
+# artifact instead of recompiling sources. Include dirs and the language standard
+# are PUBLIC so both consumers inherit them.
+add_library(cpp_boilerplate_lib STATIC src/split.cpp)
+target_include_directories(cpp_boilerplate_lib PUBLIC ${PROJECT_SOURCE_DIR}/include)
+target_compile_features(cpp_boilerplate_lib PUBLIC cxx_std_23)
+enable_project_options(cpp_boilerplate_lib)
+
+# --- application -----------------------------------------------------------
+add_executable(cpp_boilerplate src/main.cpp)
+target_link_libraries(cpp_boilerplate PRIVATE cpp_boilerplate_lib spdlog::spdlog)
+enable_project_options(cpp_boilerplate)
 
 # --- tests -----------------------------------------------------------------
 if(BUILD_TESTING)
     find_package(GTest CONFIG REQUIRED)
     include(GoogleTest)
-    add_executable(split_test tests/split_test.cpp src/split.cpp)
-    target_compile_features(split_test PRIVATE cxx_std_23)
-    target_include_directories(split_test PRIVATE ${PROJECT_SOURCE_DIR}/include)
-    target_link_libraries(split_test PRIVATE GTest::gtest_main)
-    enable_project_warnings(split_test)
-    enable_sanitizers(split_test)
-    enable_coverage(split_test)
-    gtest_discover_tests(split_test DISCOVERY_MODE PRE_TEST)
+    add_executable(split_test tests/split_test.cpp)
+    target_link_libraries(split_test PRIVATE cpp_boilerplate_lib GTest::gtest_main)
+    enable_project_options(split_test)
+
+    # Each test process writes its own raw profile (%p pid, %m binary id) so the
+    # source-based coverage data from all tests can be merged. Harmless for the
+    # non-coverage presets, whose binaries are not instrumented.
+    set(coverage_profile "LLVM_PROFILE_FILE=${CMAKE_BINARY_DIR}/profraw/%p-%m.profraw")
+
+    gtest_discover_tests(split_test DISCOVERY_MODE PRE_TEST
+                         PROPERTIES ENVIRONMENT "${coverage_profile}"
+    )
 
     # Smoke test: the application binary runs to completion and exits cleanly.
     # Complements the unit tests by exercising src/main.cpp, including under the
     # sanitizer and coverage presets.
     add_test(NAME AppTest.RunsToCompletion COMMAND cpp_boilerplate)
-    set_tests_properties(AppTest.RunsToCompletion PROPERTIES PASS_REGULAR_EXPRESSION "done")
+    set_tests_properties(AppTest.RunsToCompletion PROPERTIES
+                         PASS_REGULAR_EXPRESSION "done" ENVIRONMENT "${coverage_profile}"
+    )
 endif()

--- a/Makefile
+++ b/Makefile
@@ -5,21 +5,24 @@ CMAKE_ARGS ?=
 COLOR_CYAN := \033[36m
 COLOR_RESET := \033[0m
 
-GCOV_EXECUTABLE_Linux := gcov
-GCOV_EXECUTABLE_Darwin := xcrun llvm-cov gcov
-
+# Coverage uses two toolchains: Clang builds emit source-based profiles read by
+# llvm-cov; GCC builds emit gcov data read by gcovr. coverage-report auto-selects
+# based on which artifacts the build produced.
 ifeq ($(UNAME_S),Darwin)
 HOMEBREW_LLVM_PREFIX := $(shell brew --prefix llvm 2>/dev/null)
 ifneq ($(HOMEBREW_LLVM_PREFIX),)
 export PATH := $(HOMEBREW_LLVM_PREFIX)/bin:$(PATH)
 endif
+# xcrun resolves the LLVM tools from the active Xcode toolchain, matching the
+# AppleClang that produced the .profraw files.
+LLVM_PROFDATA ?= xcrun llvm-profdata
+LLVM_COV ?= xcrun llvm-cov
+else
+LLVM_PROFDATA ?= llvm-profdata
+LLVM_COV ?= llvm-cov
 endif
 
-GCOV_EXECUTABLE ?= $(GCOV_EXECUTABLE_$(UNAME_S))
-
-ifeq ($(GCOV_EXECUTABLE),)
-$(error unsupported host OS '$(UNAME_S)'; set GCOV_EXECUTABLE='<cmd>' to override)
-endif
+GCOV_EXECUTABLE ?= gcov
 
 .DEFAULT_GOAL := help
 
@@ -47,7 +50,15 @@ CONAN_STAMP_coverage := debug
 # ---------------------------------------------------------------------------
 STAMP_DIR := build/.stamps
 COVERAGE_DIR := build/coverage
-COVERAGE_FAIL_UNDER ?= 70
+# Floor is shared by both report paths. gcov and llvm-cov count lines differently
+# (gcov 74.1%, llvm-cov 86.1% for the same code on CI), so it tracks the lower
+# gcov figure: 74 is the tightest integer the gcov path clears (75 would fail).
+COVERAGE_FAIL_UNDER ?= 74
+COVERAGE_PROFRAW := $(COVERAGE_DIR)/profraw
+COVERAGE_PROFDATA := $(COVERAGE_DIR)/coverage.profdata
+# Report merged coverage for both binaries, restricted to first-party sources.
+COVERAGE_OBJECTS := $(COVERAGE_DIR)/cpp_boilerplate -object $(COVERAGE_DIR)/split_test
+COVERAGE_SOURCES := $(CURDIR)/src $(CURDIR)/include
 FORMAT_SOURCES = $(shell find include src tests -type f \( -name '*.hpp' -o -name '*.cpp' \))
 TIDY_SOURCES = $(shell find src tests -type f -name '*.cpp')
 
@@ -119,20 +130,40 @@ debug release sanitize coverage: %: $(STAMP_DIR)/$$(CONAN_STAMP_%).stamp
 # ---------------------------------------------------------------------------
 .PHONY: coverage-data-clean
 coverage-data-clean:
-	-find $(COVERAGE_DIR) -name '*.gcda' -delete
+	-rm -rf $(COVERAGE_PROFRAW) $(COVERAGE_PROFDATA) $(COVERAGE_DIR)/default.profraw
+	-find $(COVERAGE_DIR) -name '*.gcda' -delete 2>/dev/null
 
-.PHONY: coverage-report
-coverage-report: coverage ## Generate gcovr coverage report after running coverage
+.PHONY: coverage-report coverage-report-llvm coverage-report-gcov
+coverage-report: coverage ## Generate an HTML coverage report and enforce the line floor
 	$(call require-tool,python3)
+	@if ls $(COVERAGE_PROFRAW)/*.profraw >/dev/null 2>&1; then \
+		$(MAKE) --no-print-directory coverage-report-llvm; \
+	else \
+		$(MAKE) --no-print-directory coverage-report-gcov; \
+	fi
+
+# Clang source-based coverage via llvm-cov (HTML + lcov + line floor).
+coverage-report-llvm:
+	$(LLVM_PROFDATA) merge -sparse $(COVERAGE_PROFRAW)/*.profraw -o $(COVERAGE_PROFDATA)
+	$(LLVM_COV) show $(COVERAGE_OBJECTS) -instr-profile=$(COVERAGE_PROFDATA) \
+		-format=html -output-dir=$(COVERAGE_DIR)/coverage-report $(COVERAGE_SOURCES)
+	$(LLVM_COV) export -format=lcov $(COVERAGE_OBJECTS) -instr-profile=$(COVERAGE_PROFDATA) \
+		$(COVERAGE_SOURCES) > $(COVERAGE_DIR)/coverage.lcov
+	$(LLVM_COV) report $(COVERAGE_OBJECTS) -instr-profile=$(COVERAGE_PROFDATA) $(COVERAGE_SOURCES)
+	$(LLVM_COV) export -summary-only $(COVERAGE_OBJECTS) -instr-profile=$(COVERAGE_PROFDATA) \
+		$(COVERAGE_SOURCES) | python3 -c 'import json, sys; \
+		pct = json.load(sys.stdin)["data"][0]["totals"]["lines"]["percent"]; floor = float(sys.argv[1]); \
+		print("line coverage %.1f%% (floor %s%%)" % (pct, sys.argv[1])); \
+		sys.exit(0 if pct >= floor else 1)' $(COVERAGE_FAIL_UNDER)
+
+# GCC gcov coverage via gcovr (HTML + Cobertura + line floor).
+coverage-report-gcov:
 	mkdir -p $(COVERAGE_DIR)/coverage-report
-	python3 -m gcovr --root . \
-		--gcov-executable "$(GCOV_EXECUTABLE)" \
-		--filter 'include/' --filter 'src/' \
-		--exclude 'tests/' \
+	python3 -m gcovr --root . --gcov-executable "$(GCOV_EXECUTABLE)" \
+		--filter 'include/' --filter 'src/' --exclude 'tests/' \
 		--html-details $(COVERAGE_DIR)/coverage-report/index.html \
 		--cobertura $(COVERAGE_DIR)/coverage.xml \
-		--txt-summary \
-		--fail-under-line $(COVERAGE_FAIL_UNDER) \
+		--txt-summary --fail-under-line $(COVERAGE_FAIL_UNDER) \
 		$(COVERAGE_DIR)
 
 # ---------------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -137,16 +137,24 @@ make lint
 
 ## Coverage
 
-Generate a gcovr Cobertura report and HTML report with:
+Build, test, and generate an HTML coverage report with an enforced line floor:
 
 ```console
-make coverage
+make coverage-report
 ```
 
-This writes:
+Coverage supports both compilers and selects the matching toolchain automatically
+from the build artifacts:
 
-- `build/coverage/coverage.xml`
-- `build/coverage/coverage-report/index.html`
+- **Clang / AppleClang**: source-based instrumentation reported by `llvm-cov`.
+  Writes `coverage-report/index.html` and `coverage.lcov` under `build/coverage/`.
+- **GCC**: `gcov` instrumentation reported by `gcovr` (`pip install gcovr`). Writes
+  `coverage-report/index.html` and `coverage.xml` under `build/coverage/`.
+
+The report fails if line coverage falls below `COVERAGE_FAIL_UNDER` (default 74;
+override with `make coverage-report COVERAGE_FAIL_UNDER=80`). `gcov` and `llvm-cov`
+count lines differently (gcov reports lower), so the floor tracks the gcov figure
+so both paths pass.
 
 ## IDE setup
 


### PR DESCRIPTION
Addresses critique items #4 (legacy coverage fought good structure) and #5 (no library/app separation) together — and keeps GCC coverage.

## Library target (restored)

`src/split.cpp` is compiled once into `cpp_boilerplate_lib`; the application and the tests link it instead of recompiling the source. Include dirs and the language standard are `PUBLIC` so both consumers inherit them.

## Why this works now (it was reverted before)

The library was reverted earlier because gcov split `.gcno`/`.gcda` across directories under **AppleClang**. The fix is the right coverage mechanism per compiler:

- **Clang / AppleClang** → source-based coverage (`-fprofile-instr-generate -fcoverage-mapping`), reported by `llvm-cov`. No `.gcno`/`.gcda` split. Outputs HTML + `coverage.lcov`.
- **GCC** → `gcov` instrumentation, reported by `gcovr`. The library's gcov data co-locates on GCC. Outputs HTML + `coverage.xml`.

`make coverage-report` auto-selects the toolchain from the build artifacts (`.profraw` → `llvm-cov`, `.gcda` → `gcovr`) and enforces `COVERAGE_FAIL_UNDER` on line coverage.

## GCC coverage is retained

Source-based coverage is Clang-only, so making it the sole mechanism would drop GCC coverage — unacceptable for a public template. The **CI coverage job runs on GCC** via the gcov path, so GCC coverage stays a first-class, CI-gated capability. The clang/llvm-cov path is supported and validated locally.

## Floor

`gcov` and `llvm-cov` report different line percentages for identical code. The CI figures are **gcov 74.1%** and **llvm-cov 86.1%**, so the shared `COVERAGE_FAIL_UNDER` is **74** — the tightest integer the lower (gcov) path clears. Overridable for a stricter gate.

## Verification

- Local (AppleClang): library links across `debug`/`release`/`sanitize`/`coverage`; 7/7 tests pass; source-based report at 86.1% line coverage.
- CI: all jobs green, including the GCC gcov coverage job at 74.1% against the 74 floor.
- `format-check` clean.