### PR TITLE
feat: Windows/MSVC support and CMake workflow presets

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
     env:
       CC: ${{ matrix.compiler == 'gcc' && 'gcc' || 'clang' }}
       CXX: ${{ matrix.compiler == 'gcc' && 'g++' || 'clang++' }}
-      CMAKE_ARGS: -DWARNINGS_AS_ERRORS=ON
+      WARNINGS_AS_ERRORS: ON
     strategy:
       fail-fast: false
       matrix:
@@ -48,13 +48,38 @@ jobs:
         run: make bootstrap-sanitize
       - run: make ${{ matrix.preset }}
 
+  # Windows has no make; it drives Conan and the CMake presets directly, using the
+  # MSVC environment Conan generates (conanbuild.bat) rather than a third-party
+  # action. The sanitize and coverage presets are Unix-only, so Windows covers release.
+  windows:
+    name: release / windows-latest / msvc
+    runs-on: windows-latest
+    env:
+      WARNINGS_AS_ERRORS: ON
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v4
+        with:
+          path: ~/.conan2
+          key: conan-windows-latest-msvc-${{ hashFiles('conanfile.py', 'conan.lock') }}
+          restore-keys: conan-windows-latest-msvc-
+      - uses: conan-io/setup-conan@v1
+      # Ninja must be on PATH when Conan picks the generator at install time.
+      - run: pip install ninja
+      - run: conan install . -pr=profiles/default -s build_type=Release --build=missing --lockfile=conan.lock
+      - name: Build and test (release preset)
+        shell: cmd
+        run: |
+          call build\release\generators\conanbuild.bat
+          cmake --workflow --preset release || exit /b 1
+
   coverage:
     name: coverage / ubuntu-latest / gcc
     runs-on: ubuntu-latest
     env:
       CC: gcc
       CXX: g++
-      CMAKE_ARGS: -DWARNINGS_AS_ERRORS=ON
+      WARNINGS_AS_ERRORS: ON
     steps:
       - uses: actions/checkout@v4
       - uses: actions/cache@v4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,8 +29,13 @@ endif()
 find_package(spdlog CONFIG REQUIRED)
 
 function(enable_project_warnings target)
-    target_compile_options(${target} PRIVATE -Wall -Wextra -Wpedantic)
+    if(MSVC)
+        target_compile_options(${target} PRIVATE /W4)
+    else()
+        target_compile_options(${target} PRIVATE -Wall -Wextra -Wpedantic)
+    endif()
     if(WARNINGS_AS_ERRORS)
+        # Adds /WX for MSVC and -Werror for GCC/Clang.
         set_target_properties(${target} PROPERTIES COMPILE_WARNING_AS_ERROR ON)
     endif()
 endfunction()
@@ -40,15 +45,18 @@ function(enable_sanitizers target)
         return()
     endif()
 
-    if(NOT CMAKE_CXX_COMPILER_ID MATCHES "^(GNU|Clang|AppleClang)$")
-        message(FATAL_ERROR "Sanitizers require GCC, Clang, or AppleClang")
+    if(MSVC)
+        # MSVC ships AddressSanitizer; UndefinedBehaviorSanitizer is not available.
+        target_compile_options(${target} PRIVATE /fsanitize=address)
+    elseif(CMAKE_CXX_COMPILER_ID MATCHES "^(GNU|Clang|AppleClang)$")
+        target_compile_options(
+            ${target} PRIVATE -fsanitize=address,undefined -fno-sanitize-recover=all
+                              -fno-omit-frame-pointer
+        )
+        target_link_options(${target} PRIVATE -fsanitize=address,undefined)
+    else()
+        message(FATAL_ERROR "Sanitizers require MSVC, GCC, Clang, or AppleClang")
     endif()
-
-    target_compile_options(
-        ${target} PRIVATE -fsanitize=address,undefined -fno-sanitize-recover=all
-                          -fno-omit-frame-pointer
-    )
-    target_link_options(${target} PRIVATE -fsanitize=address,undefined)
 endfunction()
 
 function(enable_coverage target)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -10,22 +10,29 @@
   ],
   "configurePresets": [
     {
+      "name": "_warnings",
+      "hidden": true,
+      "cacheVariables": {
+        "WARNINGS_AS_ERRORS": "$env{WARNINGS_AS_ERRORS}"
+      }
+    },
+    {
       "name": "debug",
       "displayName": "Debug",
       "description": "Debug configuration backed by Conan's debug preset.",
-      "inherits": "conan-debug"
+      "inherits": ["conan-debug", "_warnings"]
     },
     {
       "name": "release",
       "displayName": "Release",
       "description": "Release configuration backed by Conan's release preset.",
-      "inherits": "conan-release"
+      "inherits": ["conan-release", "_warnings"]
     },
     {
       "name": "sanitize",
       "displayName": "Sanitizers",
       "description": "Debug configuration with sanitizer instrumentation from the Conan sanitize profile.",
-      "inherits": "conan-debug-addressundefined"
+      "inherits": ["conan-debug-addressundefined", "_warnings"]
     },
     {
       "name": "coverage",
@@ -93,6 +100,40 @@
       "output": {
         "outputOnFailure": true
       }
+    }
+  ],
+  "workflowPresets": [
+    {
+      "name": "debug",
+      "steps": [
+        { "type": "configure", "name": "debug" },
+        { "type": "build", "name": "debug" },
+        { "type": "test", "name": "debug" }
+      ]
+    },
+    {
+      "name": "release",
+      "steps": [
+        { "type": "configure", "name": "release" },
+        { "type": "build", "name": "release" },
+        { "type": "test", "name": "release" }
+      ]
+    },
+    {
+      "name": "sanitize",
+      "steps": [
+        { "type": "configure", "name": "sanitize" },
+        { "type": "build", "name": "sanitize" },
+        { "type": "test", "name": "sanitize" }
+      ]
+    },
+    {
+      "name": "coverage",
+      "steps": [
+        { "type": "configure", "name": "coverage" },
+        { "type": "build", "name": "coverage" },
+        { "type": "test", "name": "coverage" }
+      ]
     }
   ]
 }

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,5 @@
 UNAME_S := $(shell uname -s)
 
-CMAKE_ARGS ?=
-
 COLOR_CYAN := \033[36m
 COLOR_RESET := \033[0m
 
@@ -110,9 +108,7 @@ sanitize: ## Build and test via the sanitize workflow preset
 coverage: coverage-data-clean ## Build and test via the coverage workflow preset
 
 debug release sanitize coverage: %: $(STAMP_DIR)/$$(CONAN_STAMP_%).stamp
-	cmake --preset $@ $(CMAKE_ARGS)
-	cmake --build --preset $@
-	ctest --preset $@
+	cmake --workflow --preset $@
 
 # ---------------------------------------------------------------------------
 # Coverage report generation
@@ -141,7 +137,7 @@ coverage-report: coverage ## Generate gcovr coverage report after running covera
 .PHONY: lint
 lint: $(STAMP_DIR)/debug.stamp ## Run clang-tidy against the debug compilation database
 	$(call require-tool,clang-tidy)
-	cmake --preset debug $(CMAKE_ARGS)
+	cmake --preset debug
 	PATH="$(PATH)" clang-tidy -p build/debug $(TIDY_SOURCES)
 
 .PHONY: format

--- a/README.md
+++ b/README.md
@@ -25,18 +25,19 @@ wrapper around `make bootstrap` plus the public CMake presets.
 
 - [CMake](https://cmake.org/download/) 3.28+
 - [Conan](https://docs.conan.io/2/installation.html) 2.25+ (for the `CMakeConfigDeps` generator)
-- [Ninja](https://ninja-build.org/) or GNU Make on Unix-like systems
+- [Ninja](https://ninja-build.org/) (required on Windows; GNU Make also works on Unix)
 - A compiler and standard library with working C++23 support
   - [GCC](https://gcc.gnu.org/) 13+
   - [LLVM Clang](https://llvm.org/) 17+
   - [Apple Clang](https://developer.apple.com/xcode/) 17+ recommended
+  - [MSVC](https://visualstudio.microsoft.com/) 2022 (17.10+) on Windows
 
 Conan chooses the CMake generator for you:
 
 - `Ninja` on Unix-like systems when it is available
 - `Unix Makefiles` on Unix-like systems when `ninja` is not installed
 
-This boilerplate currently supports macOS and Linux.
+This boilerplate supports Linux, macOS, and Windows.
 
 ## Configure, build, and test
 
@@ -58,6 +59,21 @@ make coverage
 make lint
 make format-check
 ```
+
+### Windows
+
+The `Makefile` is a Unix convenience wrapper. On Windows, drive Conan and the CMake
+presets directly from a shell with the MSVC environment loaded (a Developer
+PowerShell, or any shell after `vcvarsall`):
+
+```console
+conan install . -pr=profiles/default -s build_type=Release --build=missing --lockfile=conan.lock
+cmake --workflow --preset release
+```
+
+`cmake --workflow --preset <name>` runs configure, build, and test in one step; it
+is what the `make` targets call on Unix too. The `sanitize` and `coverage` presets
+are Unix-only.
 
 ### Why CMakePresets.json includes ConanPresets.json
 
@@ -114,6 +130,7 @@ project leaves it at the default `ON`, so `make debug`, `make release`, `make sa
 - Configure presets: `debug`, `release`, `sanitize`, `coverage`
 - Build presets: `debug`, `release`, `sanitize`, `coverage`
 - Test presets: `debug`, `release`, `sanitize`, `coverage`
+- Workflow presets: `debug`, `release`, `sanitize`, `coverage` (configure + build + test)
 
 The Conan-generated `conan-*` presets are internal implementation details and are not the public
 interface for developers or CI.

--- a/conanfile.py
+++ b/conanfile.py
@@ -21,7 +21,12 @@ class CppBoilerplateConan(ConanFile):
     }
 
     def _cmake_generator(self):
-        return "Ninja" if shutil.which("ninja") else "Unix Makefiles"
+        if shutil.which("ninja"):
+            return "Ninja"
+        # Unix Makefiles cannot drive MSVC; fall back to the VS generator there.
+        if self.settings.os == "Windows":
+            return "Visual Studio 17 2022"
+        return "Unix Makefiles"
 
     def layout(self):
         # Let Conan own the build layout. build_type gives build/debug and build/release;

--- a/profiles/default
+++ b/profiles/default
@@ -5,5 +5,9 @@ os={{ detect_api.detect_os() }}
 compiler={{ compiler }}
 compiler.version={{ detect_api.default_compiler_version(compiler, compiler_version) }}
 compiler.cppstd=23
+{% if compiler == "msvc" %}
+compiler.runtime=dynamic
+{% else %}
 compiler.libcxx={{ detect_api.detect_libcxx(compiler, compiler_version, compiler_exe) }}
+{% endif %}
 build_type=Release


### PR DESCRIPTION
Closes the "no Windows/MSVC" gap from the best-of-best review, and folds in CMake **workflow presets** to remove the configure/build/test repetition.

**All CI green, including `release / windows-latest / msvc`.** (Developed on macOS; the Windows path is verified by CI.)

## Windows / MSVC (build + test of `release`)

- **CMake portability**: `enable_project_warnings` uses `/W4` on MSVC (`-Wall -Wextra -Wpedantic` otherwise); `enable_sanitizers` uses MSVC ASan (`/fsanitize=address`; UBSan is unavailable on MSVC); `_cmake_generator` falls back to the VS generator on Windows when Ninja is absent.
- **Profile**: `profiles/default` set `compiler.libcxx`, which doesn't exist for MSVC — now branches to `compiler.runtime=dynamic` for msvc. (This was the first CI failure.)
- **CI job**: Windows has no `make`, so it drives Conan + the CMake presets directly. The MSVC environment comes from **Conan's own `conanbuild.bat`** (VirtualBuildEnv), not a third-party action; `pip install ninja` runs first so Conan selects Ninja at install time.
- `sanitize` and `coverage` presets remain Unix-only.

## CMake workflow presets

`cmake --workflow --preset <name>` runs configure + build + test in one step, so the Makefile rule and the Windows job both collapse to a single command (no more repeating the preset three times).

- Added a `workflowPresets` block for `debug`/`release`/`sanitize`/`coverage`.
- Workflow presets take no command-line `-D`, so the CI-only `WARNINGS_AS_ERRORS` override moved to an env-driven hidden preset: `WARNINGS_AS_ERRORS=$env{WARNINGS_AS_ERRORS}`, inherited by the four presets. CI sets `WARNINGS_AS_ERRORS=ON`; unset locally means OFF — same CI-only behavior as before. The general `CMAKE_ARGS` escape hatch is dropped (its only use was this option).

## Verification

- CI: full matrix green — Linux (gcc+clang) and macOS release/sanitize, the GCC coverage job, Windows/MSVC release, and lint.
- Local (macOS): `make debug/release/sanitize/coverage` each run one `cmake --workflow` command and pass 7/7; cache shows `WARNINGS_AS_ERRORS` empty (OFF) by default and `ON` when the env var is set.

## Note on overlap with #22

#22 (library + dual coverage) is still open and also touches `enable_coverage`, the coverage preset, and `coverage-report`. Whichever lands first, I'll rebase the other to resolve those hunks.