### PR TITLE
build: refresh spdlog/gtest pins and regenerate lock

### DIFF
--- a/conan.lock
+++ b/conan.lock
@@ -1,11 +1,13 @@
 {
     "version": "0.5",
     "requires": [
-        "spdlog/1.15.3#855569172102c04e3e0db21ae95cf017%1767604739.328",
-        "gtest/1.15.0#9eba70e54373fb7325151ad3375934a1%1743410805.366",
-        "fmt/11.2.0#579bb2cdf4a7607621beea4eb4651e0f%1746298708.362"
+        "spdlog/1.17.0#bcbaaf7147bda6ad24ffbd1ac3d7142c%1767636069.964",
+        "gtest/1.17.0#5224b3b3ff3b4ce1133cbdd27d53ee7d%1755784855.585",
+        "fmt/12.1.0#50abab23274d56bb8f42c94b3b9a40c7%1761885265.231"
     ],
-    "build_requires": [],
+    "build_requires": [
+        "cmake/4.3.3#840cf00ea09777e05c2050a50a82c722%1781521538.233"
+    ],
     "python_requires": [],
     "config_requires": []
 }

--- a/conanfile.py
+++ b/conanfile.py
@@ -12,7 +12,7 @@ class CppBoilerplateConan(ConanFile):
 
     settings = "os", "compiler", "build_type", "arch"
 
-    requires = "spdlog/1.15.3"
+    requires = "spdlog/1.17.0"
 
     default_options = {
         "spdlog/*:header_only": False,
@@ -39,7 +39,7 @@ class CppBoilerplateConan(ConanFile):
         cmake_layout(self, generator=self._cmake_generator())
 
     def build_requirements(self):
-        self.test_requires("gtest/1.15.0")
+        self.test_requires("gtest/1.17.0")
 
     def generate(self):
         # CMakeConfigDeps generates CMake CONFIG-mode find_package files under the build


### PR DESCRIPTION
Block 1 of 7 in the golden-standard sequence. Single concern: refresh direct dependency pins and regenerate the lockfile.

## Changes
- `conanfile.py`: `spdlog/1.15.3 → 1.17.0`, `gtest/1.15.0 → 1.17.0` (latest 1.x on ConanCenter)
- `conan.lock`: clean regen — now pins `spdlog/1.17.0`, `gtest/1.17.0`, `fmt/12.1.0`

## Notes
- The newer spdlog/fmt recipes introduce a **new `cmake/4.3.3` build-require** in the lock (the graph previously had none). It is a `tool_requires` used only when building dependencies from source; ConanCenter ships prebuilt binaries for common configurations.
- `fmt` stays transitive through spdlog (not added as a direct require).

## Validation
- `make debug` and `make release` both build and pass all 7 tests locally (AppleClang). CI matrix runs on this PR.