### PR TITLE
build: sanitizer runtime options, mode profiles, and AddressUndefinedBehavior rename

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -30,9 +30,21 @@
     },
     {
       "name": "sanitize",
-      "displayName": "Sanitizers",
-      "description": "Debug configuration with sanitizer instrumentation from the Conan sanitize profile.",
-      "inherits": ["conan-debug-addressundefined", "_warnings"]
+      "displayName": "Sanitizers (ASan + UBSan)",
+      "description": "Debug configuration with combined ASan+UBSan instrumentation from the Conan sanitize profile.",
+      "inherits": ["conan-debug-addressundefinedbehavior", "_warnings"]
+    },
+    {
+      "name": "sanitize-asan",
+      "displayName": "Sanitizers (ASan)",
+      "description": "Debug configuration with AddressSanitizer instrumentation from the Conan sanitize-asan profile.",
+      "inherits": ["conan-debug-address", "_warnings"]
+    },
+    {
+      "name": "sanitize-ubsan",
+      "displayName": "Sanitizers (UBSan)",
+      "description": "Debug configuration with UndefinedBehaviorSanitizer instrumentation from the Conan sanitize-ubsan profile.",
+      "inherits": ["conan-debug-undefinedbehavior", "_warnings"]
     },
     {
       "name": "coverage",
@@ -63,6 +75,16 @@
       "configuration": "Debug"
     },
     {
+      "name": "sanitize-asan",
+      "configurePreset": "sanitize-asan",
+      "configuration": "Debug"
+    },
+    {
+      "name": "sanitize-ubsan",
+      "configurePreset": "sanitize-ubsan",
+      "configuration": "Debug"
+    },
+    {
       "name": "coverage",
       "configurePreset": "coverage",
       "configuration": "Debug"
@@ -87,7 +109,26 @@
     },
     {
       "name": "sanitize",
+      "inherits": "conan-debug-addressundefinedbehavior",
       "configurePreset": "sanitize",
+      "configuration": "Debug",
+      "output": {
+        "outputOnFailure": true
+      }
+    },
+    {
+      "name": "sanitize-asan",
+      "inherits": "conan-debug-address",
+      "configurePreset": "sanitize-asan",
+      "configuration": "Debug",
+      "output": {
+        "outputOnFailure": true
+      }
+    },
+    {
+      "name": "sanitize-ubsan",
+      "inherits": "conan-debug-undefinedbehavior",
+      "configurePreset": "sanitize-ubsan",
       "configuration": "Debug",
       "output": {
         "outputOnFailure": true
@@ -125,6 +166,22 @@
         { "type": "configure", "name": "sanitize" },
         { "type": "build", "name": "sanitize" },
         { "type": "test", "name": "sanitize" }
+      ]
+    },
+    {
+      "name": "sanitize-asan",
+      "steps": [
+        { "type": "configure", "name": "sanitize-asan" },
+        { "type": "build", "name": "sanitize-asan" },
+        { "type": "test", "name": "sanitize-asan" }
+      ]
+    },
+    {
+      "name": "sanitize-ubsan",
+      "steps": [
+        { "type": "configure", "name": "sanitize-ubsan" },
+        { "type": "build", "name": "sanitize-ubsan" },
+        { "type": "test", "name": "sanitize-ubsan" }
       ]
     },
     {

--- a/Makefile
+++ b/Makefile
@@ -82,10 +82,10 @@ $(STAMP_DIR)/debug.stamp $(STAMP_DIR)/release.stamp: conan.lock
 	conan install . -pr=$(CONAN_PROFILE) -s build_type=$(BUILD_TYPE) --build=missing --lockfile=conan.lock
 	touch $@
 
-$(STAMP_DIR)/sanitize.stamp: conan.lock conan/settings_user.yml
+$(STAMP_DIR)/sanitize.stamp: conan.lock conan/settings_user.yml profiles/sanitize profiles/sanitize-common
 	echo "Installing Conan dependencies (sanitize)..."
 	mkdir -p $(STAMP_DIR)
-	conan config install conan
+	conan config install conan/
 	conan install . -pr=profiles/sanitize --build=missing --lockfile=conan.lock
 	touch $@
 

--- a/README.md
+++ b/README.md
@@ -87,10 +87,39 @@ the one-time per-clone step that materializes it.
 make sanitize
 ```
 
-This uses a dedicated sanitizer build tree (Conan names it `build/debug-addressundefined`
+This uses a dedicated sanitizer build tree (Conan names it `build/debug-addressundefinedbehavior`
 after the build type and `compiler.sanitizer` setting) and a Conan sanitize profile so
 dependencies are rebuilt with matching instrumentation, not linked from their plain
 (uninstrumented) Debug binaries.
+
+Three modes are provided, showcasing Conan profile inheritance. Each mode profile inherits a
+shared base, [`profiles/sanitize-common`](profiles/sanitize-common) (which pulls in
+`profiles/default`, sets `Debug`, and carries the common instrumentation flags and `[runenv]`),
+and appends its own `-fsanitize` flags:
+
+- `sanitize` — combined ASan + UBSan ([`profiles/sanitize`](profiles/sanitize)); driven by
+  `make sanitize` and CI.
+- `sanitize-asan` — AddressSanitizer only ([`profiles/sanitize-asan`](profiles/sanitize-asan)).
+- `sanitize-ubsan` — UndefinedBehaviorSanitizer only
+  ([`profiles/sanitize-ubsan`](profiles/sanitize-ubsan)).
+
+`make sanitize` runs the combined mode. The single-mode presets are runnable directly once
+their instrumented dependencies are installed (all three share `conan.lock`):
+
+```console
+conan config install conan/  # once; installs conan/settings_user.yml, i.e. the compiler.sanitizer setting (bootstrap-sanitize does this too)
+conan install . -pr=profiles/sanitize-asan --build=missing --lockfile=conan.lock
+cmake --workflow --preset sanitize-asan
+```
+
+Each mode gets its own `package_id` and build tree (`build/debug-address`,
+`build/debug-undefinedbehavior`, `build/debug-addressundefinedbehavior`).
+
+ASan/UBSan runtime options (`halt_on_error`, `print_stacktrace`, and related checks) live in
+`profiles/sanitize-common` under `[runenv]` (inherited by every mode). Conan injects them into
+the generated per-mode test preset, which the public `sanitize*` test preset inherits, so
+`ctest`/`cmake --workflow` runs the instrumented tests with those options — a single source of
+truth, no duplication in `CMakePresets.json`.
 
 That separation relies on a custom `compiler.sanitizer` setting defined in
 [`conan/settings_user.yml`](conan/settings_user.yml). The setting gives instrumented
@@ -100,7 +129,8 @@ Without the setting, `--build=missing` would silently reuse the uninstrumented D
 binaries.
 
 `make bootstrap-sanitize` installs that file into your Conan home with
-`conan config install conan` before resolving dependencies. This is a global Conan
+`conan config install conan/` (the repository's `conan/` directory) before resolving
+dependencies. This is a global Conan
 side effect: it adds the `compiler.sanitizer` subsetting (default `null`, omitted from
 `package_id`) and does not change non-sanitize builds.
 
@@ -127,10 +157,10 @@ project leaves it at the default `ON`, so `make debug`, `make release`, `make sa
 
 ## Public presets
 
-- Configure presets: `debug`, `release`, `sanitize`, `coverage`
-- Build presets: `debug`, `release`, `sanitize`, `coverage`
-- Test presets: `debug`, `release`, `sanitize`, `coverage`
-- Workflow presets: `debug`, `release`, `sanitize`, `coverage` (configure + build + test)
+- Configure presets: `debug`, `release`, `sanitize`, `sanitize-asan`, `sanitize-ubsan`, `coverage`
+- Build presets: `debug`, `release`, `sanitize`, `sanitize-asan`, `sanitize-ubsan`, `coverage`
+- Test presets: `debug`, `release`, `sanitize`, `sanitize-asan`, `sanitize-ubsan`, `coverage`
+- Workflow presets: `debug`, `release`, `sanitize`, `sanitize-asan`, `sanitize-ubsan`, `coverage` (configure + build + test)
 
 The Conan-generated `conan-*` presets are internal implementation details and are not the public
 interface for developers or CI.
@@ -204,5 +234,5 @@ CLion can use the same public presets. Run `make bootstrap` first, then in CLion
 - `tests/`: unit tests
 - `conanfile.py`: Conan dependency definition
 - `conan/settings_user.yml`: custom `compiler.sanitizer` setting for instrumented dependency builds
-- `profiles/`: Conan profiles (`default`, `sanitize`)
+- `profiles/`: Conan profiles (`default`; `sanitize-common` base inherited by `sanitize`, `sanitize-asan`, `sanitize-ubsan`)
 - `CMakePresets.json`: project-owned public presets

--- a/conan/settings_user.yml
+++ b/conan/settings_user.yml
@@ -7,11 +7,14 @@
 #
 # The value only separates package_id; the actual flags are injected by
 # profiles/sanitize. `null` is the default (no sanitizer) and is omitted from
-# package_id, so non-sanitize builds are unaffected.
+# package_id, so non-sanitize builds are unaffected. Each value maps to a profile that
+# inherits profiles/sanitize-common: Address -> sanitize-asan, UndefinedBehavior ->
+# sanitize-ubsan, AddressUndefinedBehavior -> sanitize. To support another (e.g. Thread),
+# add its value here and a matching profile.
 compiler:
     apple-clang:
-        sanitizer: [null, Address, Undefined, AddressUndefined]
+        sanitizer: [null, Address, UndefinedBehavior, AddressUndefinedBehavior]
     clang:
-        sanitizer: [null, Address, Undefined, AddressUndefined]
+        sanitizer: [null, Address, UndefinedBehavior, AddressUndefinedBehavior]
     gcc:
-        sanitizer: [null, Address, Undefined, AddressUndefined]
+        sanitizer: [null, Address, UndefinedBehavior, AddressUndefinedBehavior]

--- a/conanfile.py
+++ b/conanfile.py
@@ -47,7 +47,8 @@ class CppBoilerplateConan(ConanFile):
     def layout(self):
         # Let Conan own the build layout. build_type gives build/debug and build/release;
         # compiler.sanitizer (see conan/settings_user.yml) splits the instrumented build
-        # into build/debug-addressundefined with its own conan-debug-addressundefined
+        # into build/debug-addressundefinedbehavior with its own
+        # conan-debug-addressundefinedbehavior
         # preset. An unset or undefined sanitizer is omitted, so plain Debug builds (and
         # clones without settings_user.yml) are unaffected. Coverage is not a Conan
         # dimension; its CMake preset reuses the debug toolchain.

--- a/profiles/sanitize
+++ b/profiles/sanitize
@@ -1,14 +1,12 @@
-include(./default)
+# Combined ASan + UBSan; the mode driven by `make sanitize` and CI. Inherits the shared base
+# and appends both instrumentations.
+include(./sanitize-common)
 
 [settings]
-build_type=Debug
-# Distinct package_id for instrumented dependency binaries. The flags below do the
-# actual instrumentation; this setting only keeps them from sharing a plain-Debug
-# package_id. Requires conan/settings_user.yml (installed by `make bootstrap-sanitize`).
-compiler.sanitizer=AddressUndefined
+compiler.sanitizer=AddressUndefinedBehavior
 
 [conf]
-tools.build:cflags=["-fsanitize=address,undefined", "-fno-omit-frame-pointer", "-fno-sanitize-recover=all"]
-tools.build:cxxflags=["-fsanitize=address,undefined", "-fno-omit-frame-pointer", "-fno-sanitize-recover=all"]
+tools.build:cflags+=["-fsanitize=address,undefined"]
+tools.build:cxxflags+=["-fsanitize=address,undefined"]
 tools.build:sharedlinkflags=["-fsanitize=address,undefined"]
 tools.build:exelinkflags=["-fsanitize=address,undefined"]

--- a/profiles/sanitize-asan
+++ b/profiles/sanitize-asan
@@ -1,0 +1,11 @@
+# AddressSanitizer only. Inherits the shared base and appends address instrumentation.
+include(./sanitize-common)
+
+[settings]
+compiler.sanitizer=Address
+
+[conf]
+tools.build:cflags+=["-fsanitize=address"]
+tools.build:cxxflags+=["-fsanitize=address"]
+tools.build:sharedlinkflags=["-fsanitize=address"]
+tools.build:exelinkflags=["-fsanitize=address"]

--- a/profiles/sanitize-common
+++ b/profiles/sanitize-common
@@ -1,0 +1,22 @@
+# Shared base for the sanitizer profiles. Each mode profile (sanitize-asan, sanitize-ubsan,
+# sanitize) inherits this with include() and appends its own -fsanitize=... flags. Requires
+# conan/settings_user.yml (installed by `make bootstrap-sanitize`) for the compiler.sanitizer
+# subsetting, which gives instrumented dependency binaries a distinct package_id.
+include(./default)
+
+[settings]
+build_type=Debug
+
+[conf]
+# Instrumentation flags common to every mode; leaves append -fsanitize=<modes> with +=.
+tools.build:cflags=["-fno-omit-frame-pointer", "-fno-sanitize-recover=all"]
+tools.build:cxxflags=["-fno-omit-frame-pointer", "-fno-sanitize-recover=all"]
+
+# Sanitizer runtime options, and the single source of truth for them. Conan injects [runenv]
+# into the generated conan-debug-<sanitizer> CMake test presets (and conanrun env scripts);
+# the public sanitize* test presets in CMakePresets.json inherit those, so `ctest`/`cmake
+# --workflow` runs the instrumented tests with these options. ASAN_OPTIONS is ignored by a
+# UBSan-only build and UBSAN_OPTIONS by an ASan-only build, so both are safe for every mode.
+[runenv]
+ASAN_OPTIONS=halt_on_error=1:abort_on_error=1:print_stacktrace=1:check_initialization_order=1:detect_stack_use_after_return=1:strict_string_checks=1
+UBSAN_OPTIONS=halt_on_error=1:print_stacktrace=1

--- a/profiles/sanitize-ubsan
+++ b/profiles/sanitize-ubsan
@@ -1,0 +1,11 @@
+# UndefinedBehaviorSanitizer only. Inherits the shared base and appends UB instrumentation.
+include(./sanitize-common)
+
+[settings]
+compiler.sanitizer=UndefinedBehavior
+
+[conf]
+tools.build:cflags+=["-fsanitize=undefined"]
+tools.build:cxxflags+=["-fsanitize=undefined"]
+tools.build:sharedlinkflags=["-fsanitize=undefined"]
+tools.build:exelinkflags=["-fsanitize=undefined"]


### PR DESCRIPTION
Block 3 of 7. Three related changes to the sanitizer setup.

## 1. Runtime options (single source of truth)
`ASAN_OPTIONS`/`UBSAN_OPTIONS` (`halt_on_error`, `print_stacktrace`, `check_initialization_order`, `detect_stack_use_after_return`, `strict_string_checks`; UBSan `halt_on_error`+`print_stacktrace`) are declared once in `profiles/sanitize-common` under `[runenv]`. Conan injects them into the generated per-mode CMake **test** presets, which the public `sanitize*` test presets inherit — so `ctest`/`cmake --workflow` run the instrumented tests with those options, with **no duplication** in `CMakePresets.json`.

- `detect_leaks` intentionally omitted: LSan is unsupported on the macOS sanitize leg; Linux ASan enables it by default.
- Verified propagation: a temporary `verbosity=1` in `[runenv]` produced the ASan banner from the ctest test processes.

## 2. Rename `AddressUndefined` → `AddressUndefinedBehavior`
Aligns with the Conan sanitizer examples. Touches `settings_user.yml`, the profiles, `CMakePresets.json` inherits, a `conanfile.py` comment, and README. `ConanPresets.json` is gitignored/generated; the renamed `conan-debug-addressundefinedbehavior` preset comes from `build_folder_vars`.

## 3. Three modes — profile-inheritance showcase
- `profiles/sanitize-common` — shared base: `include(./default)`, `Debug`, common instrumentation flags, `[runenv]`.
- `profiles/sanitize-asan` (Address), `profiles/sanitize-ubsan` (UndefinedBehavior), `profiles/sanitize` (combined) each `include(./sanitize-common)` and append `-fsanitize=...` via `+=`.
- `settings_user.yml` enum restored to `[null, Address, UndefinedBehavior, AddressUndefinedBehavior]`.
- `CMakePresets.json`: added configure/build/test/workflow presets for `sanitize-asan` and `sanitize-ubsan`; each test preset inherits the matching `conan-debug-<mode>` for `[runenv]`.
- **Make targets + CI stay on the combined mode**; single-mode presets are runnable after `conan install -pr=profiles/sanitize-<mode>`. README documents this.

Fresh-clone safety: Conan's CMakeToolchain synthesizes placeholder `conan-debug-<mode>` presets in the generated `ConanPresets.json`, so `cmake --list-presets` works after plain `make bootstrap` (verified).

## Also
- Sanitize stamp depends on `profiles/sanitize` + `profiles/sanitize-common`.
- `conan config install conan/` (directory form) for readability.

## Validation (local, AppleClang)
- Clean `make bootstrap` → all modes list, placeholders synthesized, no error.
- All three modes build + test 7/7: `make sanitize`, `cmake --workflow --preset sanitize-asan`, `... sanitize-ubsan`. Distinct build trees `build/debug-address`, `-undefinedbehavior`, `-addressundefinedbehavior`.