### PR TITLE
ci: add lock-check, pin Conan, and use the action's package cache

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,10 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  # Pin the Conan version for reproducible CI. Bump here in one place.
+  CONAN_VERSION: "2.29.1"
+
 jobs:
   build:
     name: ${{ matrix.preset }} / ${{ matrix.os }} / ${{ matrix.compiler }}
@@ -33,16 +37,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/cache@v4
-        with:
-          path: ~/.conan2
-          key: conan-${{ matrix.os }}-${{ matrix.compiler }}-${{ hashFiles('conanfile.py', 'conan.lock') }}
-          restore-keys: conan-${{ matrix.os }}-${{ matrix.compiler }}-
       - uses: conan-io/setup-conan@v1
-      - name: Verify conan.lock freshness
-        run: |
-          conan lock create . -pr=profiles/default --lockfile-out=/tmp/fresh.lock
-          diff conan.lock /tmp/fresh.lock
+        with:
+          version: ${{ env.CONAN_VERSION }}
+          cache_packages: true
+      - run: make lock-check
       - run: make bootstrap
       - if: matrix.preset == 'sanitize'
         run: make bootstrap-sanitize
@@ -64,12 +63,10 @@ jobs:
       WARNINGS_AS_ERRORS: ON
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/cache@v4
-        with:
-          path: ~/.conan2
-          key: conan-windows-latest-msvc-${{ hashFiles('conanfile.py', 'conan.lock') }}
-          restore-keys: conan-windows-latest-msvc-
       - uses: conan-io/setup-conan@v1
+        with:
+          version: ${{ env.CONAN_VERSION }}
+          cache_packages: true
       # Ninja must be on PATH when Conan picks the generator at install time.
       - run: pip install ninja
       - run: conan install . -pr=profiles/default -s build_type=Release --build=missing --lockfile=conan.lock
@@ -93,12 +90,10 @@ jobs:
       WARNINGS_AS_ERRORS: ON
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/cache@v4
-        with:
-          path: ~/.conan2
-          key: conan-ubuntu-latest-gcc-${{ hashFiles('conanfile.py', 'conan.lock') }}
-          restore-keys: conan-ubuntu-latest-gcc-
       - uses: conan-io/setup-conan@v1
+        with:
+          version: ${{ env.CONAN_VERSION }}
+          cache_packages: true
       - run: python3 -m pip install --break-system-packages --user gcovr
       - run: make bootstrap
       # Builds, runs the suite, and fails if line coverage drops below the floor.
@@ -113,6 +108,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: conan-io/setup-conan@v1
+        with:
+          version: ${{ env.CONAN_VERSION }}
+          cache_packages: true
       - run: make bootstrap
       - run: make format-check
       - run: make lint

--- a/Makefile
+++ b/Makefile
@@ -187,7 +187,21 @@ format-check: ## Fail if C++ sources are not clang-format clean
 # Lock and clean
 # ---------------------------------------------------------------------------
 .PHONY: lock
-lock: conan.lock ## Ensure conan.lock is up to date
+lock: ## Force-regenerate conan.lock from conanfile.py
+	echo "Regenerating conan.lock..."
+	conan lock create . -pr=$(CONAN_PROFILE) --lockfile-out=conan.lock
+
+.PHONY: lock-check
+lock-check: ## Fail if conan.lock is out of date with conanfile.py (used by CI)
+	tmp=$$(mktemp); \
+	conan lock create . -pr=$(CONAN_PROFILE) --lockfile-out=$$tmp >/dev/null 2>&1 \
+		|| { echo "ERROR: conan lock create failed"; rm -f $$tmp; exit 1; }; \
+	if diff conan.lock $$tmp >/dev/null; then \
+		rm -f $$tmp; echo "conan.lock is up to date"; \
+	else \
+		echo "ERROR: conan.lock is stale; run 'make lock' and commit the result"; \
+		diff conan.lock $$tmp || true; rm -f $$tmp; exit 1; \
+	fi
 
 .PHONY: clean
 clean: ## Remove generated build artifacts and Conan preset files


### PR DESCRIPTION
Block 5 of 7. Makefile + workflow only (no source/build-logic changes).

## Makefile
- `make lock` now **force-regenerates** `conan.lock` (was lazy via the file target).
- New **`make lock-check`**: regenerate to a temp lockfile and diff against the committed `conan.lock`; fails (printing the diff) if stale. The `conan.lock` file rule is kept so the stamp targets still auto-regenerate during the local build loop.
- Tested locally: fresh → pass; `make lock` → idempotent (no git diff); corrupted lock → exit 1; create-failure handled.

## CI
- Pin the Conan version once via a top-level `CONAN_VERSION` (`2.29.1`) and pass `version:` to every `setup-conan@v1`.
- Enable the action's built-in package cache (`cache_packages: true`) and **remove** the hand-rolled `actions/cache` blocks. The action caches `<conan-home>/p` keyed `conan-<version>-<os>`, which covers the package store cleanly (profiles/config are recreated by `profile detect`) — confirmed from the action's `action.yml`.
- Replace the inline "Verify conan.lock freshness" step with `- run: make lock-check`.

## Notes
- Pinned to `2.29.1` to match the Conan that generated the committed lock, keeping `lock-check` consistent.
- Cache trade-off: the action key is `conan-<version>-<os>` (not keyed by conanfile/lock hash), so it refreshes on a Conan version bump rather than per dep change. The package store is additive, so dep changes still build and work — the official design.