### PR TITLE
build: pin CMake as an explicit build tool and lower the floor to 3.25

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,6 @@
-cmake_minimum_required(VERSION 3.28)
+# 3.25 is the floor bound by the features this template uses: workflow presets and
+# CMakePresets schema v6 (3.25), COMPILE_WARNING_AS_ERROR (3.24), cxx_std_23 (3.20).
+cmake_minimum_required(VERSION 3.25)
 
 project(
     cpp_boilerplate

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -2,7 +2,7 @@
   "version": 6,
   "cmakeMinimumRequired": {
     "major": 3,
-    "minor": 28,
+    "minor": 25,
     "patch": 0
   },
   "include": [

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build](https://github.com/megabyde/cpp-boilerplate/actions/workflows/build.yml/badge.svg)](https://github.com/megabyde/cpp-boilerplate/actions/workflows/build.yml)
 [![C++23](https://img.shields.io/badge/C%2B%2B-23-blue.svg)](https://en.cppreference.com/w/cpp/23)
-[![CMake](https://img.shields.io/badge/CMake-3.28%2B-064F8C.svg)](https://cmake.org)
+[![CMake](https://img.shields.io/badge/CMake-3.25%2B-064F8C.svg)](https://cmake.org)
 [![Conan](https://img.shields.io/badge/Conan-2.x-6699CB.svg)](https://conan.io)
 [![License](https://img.shields.io/badge/license-Unlicense-green.svg)](LICENSE)
 
@@ -23,7 +23,7 @@ wrapper around `make bootstrap` plus the public CMake presets.
 
 ## Prerequisites
 
-- [CMake](https://cmake.org/download/) 3.28+
+- [CMake](https://cmake.org/download/) 3.25+ (for workflow presets)
 - [Conan](https://docs.conan.io/2/installation.html) 2.25+ (for the `CMakeConfigDeps` generator)
 - [Ninja](https://ninja-build.org/) (required on Windows; GNU Make also works on Unix)
 - A compiler and standard library with working C++23 support

--- a/conan.lock
+++ b/conan.lock
@@ -6,7 +6,7 @@
         "fmt/12.1.0#50abab23274d56bb8f42c94b3b9a40c7%1761885265.231"
     ],
     "build_requires": [
-        "cmake/4.3.3#840cf00ea09777e05c2050a50a82c722%1781521538.233"
+        "cmake/3.25#platform"
     ],
     "python_requires": [],
     "config_requires": []

--- a/conanfile.py
+++ b/conanfile.py
@@ -64,6 +64,12 @@ class CppBoilerplateConan(ConanFile):
         cmake_layout(self, generator=self._cmake_generator())
 
     def build_requirements(self):
+        # Declare CMake as an explicit build tool. The range matches the project floor and is
+        # satisfied from the system CMake via [platform_tool_requires] in profiles/default (so
+        # the lock records cmake/<floor>#platform, not a downloaded package). Our own targets
+        # build via `cmake --workflow`; the generator (Ninja or Makefiles) is left to the
+        # environment, not pinned here.
+        self.tool_requires("cmake/[>=3.25]")
         if self.options.with_tests:
             self.test_requires("gtest/1.17.0")
 

--- a/profiles/default
+++ b/profiles/default
@@ -11,3 +11,12 @@ compiler.runtime=dynamic
 compiler.libcxx={{ detect_api.detect_libcxx(compiler, compiler_version, compiler_exe) }}
 {% endif %}
 build_type=Release
+
+# Satisfy the cmake build tool (declared in conanfile.py) from the system CMake instead of
+# downloading the Conan package. Everyone building this project already has CMake on PATH for
+# `cmake --workflow`, so this avoids a redundant download. The version is the project's
+# documented floor (also >= gtest's own cmake requirement), which unifies the whole build
+# graph onto one platform node. Conan does not verify the PATH cmake's version against this;
+# it trusts that whatever is on PATH satisfies the range. cmake_minimum_required enforces it.
+[platform_tool_requires]
+cmake/3.25


### PR DESCRIPTION
## Summary

Block 6 of 7. Makes CMake a declared, floor-pinned build tool without adding a download, and lowers the project's CMake floor to its true minimum.

**Pin CMake as an explicit build tool.** `conanfile.py` now declares `tool_requires("cmake/[>=3.25]")`, satisfied from the system CMake via `[platform_tool_requires] cmake/3.25` in `profiles/default`. It resolves as `cmake/3.25#platform` (no download) and unifies our `>=3.25` range with gtest's transitive `>=3.16` onto a single platform node. gtest already pulled cmake into the build graph, so the lock carried a cmake build-require regardless; declaring it ourselves makes the dependency intentional and floor-controlled instead of an implicit side effect. Because the platform version is the profile literal (not the runner's installed cmake), `conan.lock` is deterministic across runners and CI `make lock-check` stays stable.

**Lower the CMake floor 3.28 → 3.25 (the true minimum).** The floor is bound by the features actually used: workflow presets + `CMakePresets` schema v6 (3.25), `COMPILE_WARNING_AS_ERROR` (3.24), `cxx_std_23` (3.20). 3.28 was conservative and arbitrary.

## Changes

- `conanfile.py`: `build_requirements()` declares `cmake/[>=3.25]`.
- `profiles/default`: `[platform_tool_requires] cmake/3.25` satisfies it from system CMake.
- `CMakeLists.txt`: `cmake_minimum_required(VERSION 3.25)` + comment naming what binds the floor.
- `CMakePresets.json`: `cmakeMinimumRequired.minor` 28 → 25.
- `README.md`: CMake badge and prerequisite 3.28+ → 3.25+.
- `conan.lock`: `build_requires` `cmake/4.3.3#840cf00…` (downloadable) → `cmake/3.25#platform`.

## Validation

Local, macOS, system cmake 4.3.4:

- `make debug` — 7/7 tests pass
- `make sanitize` — 7/7 (dependencies rebuilt from source via the platform cmake)
- `make format-check`, `make lock-check` — clean
- graph inspection: single `cmake/3.25#platform` node, no cmake download

Not empirically tested on an actual CMake 3.25 (local toolchain is 4.3.4); the floor is derived from the CMake feature-to-version documentation. CI runners cover Linux, macOS, and Windows.