### PR TITLE
docs: give the README a single operating-model anchor

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,26 @@ This repository uses:
 - [spdlog](https://github.com/gabime/spdlog) via Conan as the sample compiled dependency
 - [GoogleTest](https://github.com/google/googletest) via Conan
 
-The checked-in presets are the source of truth. [`Makefile`](Makefile) is a thin convenience
-wrapper around `make bootstrap` plus the public CMake presets.
+## Operating model
+
+The build is layered, and each layer owns one thing:
+
+- **Conan** owns the dependency graph, the toolchain, the CMake generator, and the ABI-relevant
+  settings. It resolves them from [`conanfile.py`](conanfile.py) and the [`profiles/`](profiles)
+  files; [`conan.lock`](conan.lock) pins the exact graph for reproducible builds.
+- **CMake presets** ([`CMakePresets.json`](CMakePresets.json)) are the public build interface:
+  the `debug`, `release`, `sanitize*`, and `coverage` names you configure, build, and test. They
+  are checked in and are the source of truth for how the project is built.
+- Conan writes its toolchain details into a generated `ConanPresets.json` that
+  `CMakePresets.json` includes. That file is an implementation detail, not an interface;
+  `make bootstrap` is the one-time per-clone step that materializes it.
+- The [`Makefile`](Makefile) is a thin convenience wrapper: each target runs `conan install` for
+  the right profile, then `cmake --workflow --preset <name>`. On Windows you run those two
+  commands directly (see [Windows](#windows)).
+
+When you change the Conan configuration (versions, options, or profile), rerun `make bootstrap` or
+the matching `make` target and keep using the same public preset names. The preset interface is
+stable across toolchain changes.
 
 ## Prerequisites
 
@@ -74,12 +92,6 @@ cmake --workflow --preset release
 `cmake --workflow --preset <name>` runs configure, build, and test in one step; it
 is what the `make` targets call on Unix too. The `sanitize` and `coverage` presets
 are Unix-only.
-
-### Why CMakePresets.json includes ConanPresets.json
-
-The checked-in `CMakePresets.json` owns the public preset names. Conan owns toolchain details. The
-generated `ConanPresets.json` is an implementation detail, not an interface; `make bootstrap` is
-the one-time per-clone step that materializes it.
 
 ### Sanitizers (ASAN + UBSAN)
 
@@ -143,11 +155,6 @@ the CMake `ENABLE_SANITIZERS` option, which would double the flags. `ENABLE_SANI
 remains a standalone option for instrumenting first-party code without the Conan
 profile, e.g. `cmake --preset debug -DENABLE_SANITIZERS=ON` (dependencies stay
 uninstrumented in that mode).
-
-> [!NOTE]
-> Conan owns the dependency graph, generator, toolchain, and ABI settings. If you switch the Conan
-> configuration, rerun `make bootstrap` or the matching public `make` target and keep using the
-> same public CMake preset names.
 
 ### Tests
 


### PR DESCRIPTION
## Summary

Final block (7 of 7). The README documented the mechanics well, but the *mental model* — which layer owns what — was scattered across the Overview, a standalone "Why CMakePresets.json includes ConanPresets.json" subsection, and a NOTE buried deep in the Sanitizers section. This consolidates it into one section near the top and removes the duplication.

## Changes

- **New `## Operating model` section** (after Overview) states the layering once:
  - Conan owns the dependency graph, toolchain, generator, and ABI settings (`conanfile.py` + `profiles/`); `conan.lock` pins the graph.
  - CMake presets (`CMakePresets.json`) are the public build interface — checked in, source of truth.
  - The generated `ConanPresets.json` is an implementation detail that `CMakePresets.json` includes; `make bootstrap` materializes it per clone.
  - The `Makefile` is a thin wrapper (`conan install` + `cmake --workflow --preset`); Windows runs the two commands directly.
  - Closing note: change the Conan config → rerun `bootstrap`/target, keep the same preset names.
- **Removed** (folded into the above): the standalone `### Why CMakePresets.json includes ConanPresets.json` subsection and the redundant `> [!NOTE]` at the end of Sanitizers.

## Unchanged

Sanitizer showcase depth, Coverage, Install, IDE setup, Layout, and every concrete command. This is a restructure for conceptual framing, not a prose rewrite. Net +7 lines (+20/-13), single file, no build or CI impact.