### PR TITLE
build: lock hygiene, pinned lint toolchain, and VS generator on Windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,9 +55,10 @@ jobs:
           cmake --install build/release --prefix "$RUNNER_TEMP/install"
           "$RUNNER_TEMP/install/bin/cpp_boilerplate"
 
-  # Windows has no make; it drives Conan and the CMake presets directly, using the
-  # MSVC environment Conan generates (conanbuild.bat) rather than a third-party
-  # action. The sanitize and coverage presets are Unix-only, so Windows covers release.
+  # Windows has no make; it drives Conan and the CMake presets directly. The Visual
+  # Studio generator (selected by conanfile.py on Windows) locates MSVC itself, so no
+  # vcvars environment or third-party action is needed. The sanitize and coverage
+  # presets are Unix-only, so Windows covers release.
   windows:
     name: release / windows-latest / msvc
     runs-on: windows-latest
@@ -69,14 +70,10 @@ jobs:
         with:
           version: ${{ env.CONAN_VERSION }}
           cache_packages: true
-      # Ninja must be on PATH when Conan picks the generator at install time.
-      - run: pip install ninja
-      - run: conan install . -pr=profiles/default -s build_type=Release --build=missing --lockfile=conan.lock
+      - name: Install dependencies (release)
+        run: conan install . -pr=profiles/default -s build_type=Release --build=missing --lockfile=conan.lock
       - name: Build and test (release preset)
-        shell: cmd
-        run: |
-          call build\release\generators\conanbuild.bat
-          cmake --workflow --preset release || exit /b 1
+        run: cmake --workflow --preset release
       - name: Verify install (release)
         shell: cmd
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,8 +14,10 @@ permissions:
   contents: read
 
 env:
-  # Pin the Conan version for reproducible CI. Bump here in one place.
+  # Pinned tool versions for reproducible CI. Bump here in one place.
   CONAN_VERSION: "2.29.1"
+  CLANG_FORMAT_VERSION: "21.1.8"
+  CLANG_TIDY_VERSION: "21.1.6"
 
 jobs:
   build:
@@ -111,6 +113,13 @@ jobs:
         with:
           version: ${{ env.CONAN_VERSION }}
           cache_packages: true
+      # ~/.local/bin precedes /usr/bin on the runner, so these shadow the image's
+      # unpinned clang-format/clang-tidy.
+      - name: Pin lint toolchain
+        run: |
+          python3 -m pip install --break-system-packages --user \
+            clang-format==${{ env.CLANG_FORMAT_VERSION }} \
+            clang-tidy==${{ env.CLANG_TIDY_VERSION }}
       - run: make bootstrap
       - run: make format-check
       - run: make lint

--- a/Makefile
+++ b/Makefile
@@ -67,9 +67,12 @@ endef
 # ---------------------------------------------------------------------------
 # Conan lock file (lazy — regenerated when conanfile.py changes)
 # ---------------------------------------------------------------------------
+# --lockfile-clean drops entries the current graph no longer uses; without it,
+# `conan lock create` merges into the existing lock and stale pins accumulate after
+# a version bump or a removed dependency.
 conan.lock: conanfile.py $(CONAN_PROFILE)
 	echo "Regenerating conan.lock..."
-	conan lock create . -pr=$(CONAN_PROFILE) --lockfile-out=conan.lock
+	conan lock create . -pr=$(CONAN_PROFILE) --lockfile-clean --lockfile-out=conan.lock
 
 # ---------------------------------------------------------------------------
 # Conan install
@@ -189,12 +192,12 @@ format-check: ## Fail if C++ sources are not clang-format clean
 .PHONY: lock
 lock: ## Force-regenerate conan.lock from conanfile.py
 	echo "Regenerating conan.lock..."
-	conan lock create . -pr=$(CONAN_PROFILE) --lockfile-out=conan.lock
+	conan lock create . -pr=$(CONAN_PROFILE) --lockfile-clean --lockfile-out=conan.lock
 
 .PHONY: lock-check
 lock-check: ## Fail if conan.lock is out of date with conanfile.py (used by CI)
 	tmp=$$(mktemp); \
-	conan lock create . -pr=$(CONAN_PROFILE) --lockfile-out=$$tmp >/dev/null 2>&1 \
+	conan lock create . -pr=$(CONAN_PROFILE) --lockfile-clean --lockfile-out=$$tmp >/dev/null 2>&1 \
 		|| { echo "ERROR: conan lock create failed"; rm -f $$tmp; exit 1; }; \
 	if diff conan.lock $$tmp >/dev/null; then \
 		rm -f $$tmp; echo "conan.lock is up to date"; \

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ stable across toolchain changes.
 
 - [CMake](https://cmake.org/download/) 3.25+ (for workflow presets)
 - [Conan](https://docs.conan.io/2/installation.html) 2.25+ (for the `CMakeConfigDeps` generator)
-- [Ninja](https://ninja-build.org/) (required on Windows; GNU Make also works on Unix)
+- [Ninja](https://ninja-build.org/) (optional, Unix only; GNU Make is used when absent)
 - A compiler and standard library with working C++23 support
   - [GCC](https://gcc.gnu.org/) 13+
   - [LLVM Clang](https://llvm.org/) 17+
@@ -54,6 +54,8 @@ Conan chooses the CMake generator for you:
 
 - `Ninja` on Unix-like systems when it is available
 - `Unix Makefiles` on Unix-like systems when `ninja` is not installed
+- `Visual Studio 17 2022` on Windows (multi-config; locates MSVC itself, so no extra tool
+  or `vcvars` environment is needed)
 
 This boilerplate supports Linux, macOS, and Windows.
 
@@ -81,8 +83,8 @@ make format-check
 ### Windows
 
 The `Makefile` is a Unix convenience wrapper. On Windows, drive Conan and the CMake
-presets directly from a shell with the MSVC environment loaded (a Developer
-PowerShell, or any shell after `vcvarsall`):
+presets directly from any shell; the Visual Studio generator locates MSVC on its own,
+so no Developer PowerShell or `vcvarsall` setup is required:
 
 ```console
 conan install . -pr=profiles/default -s build_type=Release --build=missing --lockfile=conan.lock

--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ Conan chooses the CMake generator for you:
 
 - `Ninja` on Unix-like systems when it is available
 - `Unix Makefiles` on Unix-like systems when `ninja` is not installed
-- `Visual Studio 17 2022` on Windows (multi-config; locates MSVC itself, so no extra tool
-  or `vcvars` environment is needed)
+- The Visual Studio generator matching the detected MSVC on Windows (multi-config; locates
+  MSVC itself, so no extra tool or `vcvars` environment is needed)
 
 This boilerplate supports Linux, macOS, and Windows.
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -46,12 +46,15 @@ class CppBoilerplateConan(ConanFile):
 
     def _cmake_generator(self):
         # Windows always uses the Visual Studio generator: it locates MSVC itself (no
-        # vcvars environment needed) and needs no extra tool on PATH. The preset names
-        # and build folders stay aligned with the single-config generators because
-        # build_folder_vars (see layout()) pins both, so the public presets are
-        # identical across platforms.
+        # vcvars environment needed) and needs no extra tool on PATH. Return None so
+        # CMakeToolchain deduces the VS release from the detected compiler.version
+        # (msvc 194 -> "Visual Studio 17 2022", 195 -> "Visual Studio 18 2026");
+        # hardcoding a year breaks when the machine has a different VS installed.
+        # The preset names and build folders stay aligned with the single-config
+        # generators because build_folder_vars (see layout()) pins both, so the
+        # public presets are identical across platforms.
         if self.settings.os == "Windows":
-            return "Visual Studio 17 2022"
+            return None
         return "Ninja" if shutil.which("ninja") else "Unix Makefiles"
 
     def layout(self):

--- a/conanfile.py
+++ b/conanfile.py
@@ -45,12 +45,14 @@ class CppBoilerplateConan(ConanFile):
         check_min_cppstd(self, 23)
 
     def _cmake_generator(self):
-        if shutil.which("ninja"):
-            return "Ninja"
-        # Unix Makefiles cannot drive MSVC; fall back to the VS generator there.
+        # Windows always uses the Visual Studio generator: it locates MSVC itself (no
+        # vcvars environment needed) and needs no extra tool on PATH. The preset names
+        # and build folders stay aligned with the single-config generators because
+        # build_folder_vars (see layout()) pins both, so the public presets are
+        # identical across platforms.
         if self.settings.os == "Windows":
             return "Visual Studio 17 2022"
-        return "Unix Makefiles"
+        return "Ninja" if shutil.which("ninja") else "Unix Makefiles"
 
     def layout(self):
         # Let Conan own the build layout. build_type gives build/debug and build/release;


### PR DESCRIPTION
Three fixes from a project evaluation pass, one commit each.

## Lock hygiene (`Makefile`)

All three `conan lock create` invocations (the `conan.lock` file rule, `make lock`, `make lock-check`) now pass `--lockfile-clean`. Without it, `conan lock create` merges into the existing lock, so a version bump or a removed dependency leaves its old pin behind forever. The existing lock is still consumed as input, so `lock-check` remains hermetic against upstream revision publishes. Verified: `make lock-check` passes and the committed lock is unchanged (no stale entries today).

## Pinned lint toolchain (CI)

The lint job previously ran whatever clang-format/clang-tidy the `ubuntu-latest` image shipped, so an image bump could turn the repo red with no repo change — the one unpinned spot in an otherwise fully pinned build. The job now installs `clang-format==21.1.8` and `clang-tidy==21.1.6` from PyPI wheels into `~/.local/bin`, which precedes `/usr/bin` on the runner. Pins live in the top-level `env` block next to `CONAN_VERSION`.

Verified locally before pinning: the repo is format-clean under 21.1.8 and emits zero tidy findings under 21.1.6 (against the macOS compile database; this PR's CI run is the first test against the gcc/libstdc++ one, and jumps CI from the image's clang-tidy 18 to 21).

## Visual Studio generator on Windows

`conanfile.py` now always uses the Visual Studio generator on Windows instead of preferring Ninja, derived from the detected `compiler.version` rather than hardcoded (windows-latest now ships VS 2026 / msvc 195, where a hardcoded `Visual Studio 17 2022` finds no VS instance), resolving the README/recipe contradiction (README claimed Ninja was required on Windows; the recipe had a silent VS fallback). The VS generator locates MSVC itself, so the Windows CI job drops `pip install ninja` and the `conanbuild.bat` call (Conan only generates VCVars scripts for Ninja/NMake generators), and the build step becomes a plain `cmake --workflow --preset release`.

Safety of the checked-in presets confirmed against the Conan 2.29.1 source: because `folders.build_folder_vars` includes `settings.build_type`, `_configure_preset_name` returns `conan-release` and the layout stays `build/release` even for a multi-config generator, so the public presets are identical across platforms. `cmake --install` defaults to the Release config for multi-config generators, so the install-verify step is unaffected.

The Windows CI job on this PR is the end-to-end test for the generator change.
