### PR TITLE
build: CI debug preset, default hardening, and warnings-as-errors by default

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,6 @@ jobs:
     env:
       CC: ${{ matrix.compiler == 'gcc' && 'gcc' || 'clang' }}
       CXX: ${{ matrix.compiler == 'gcc' && 'g++' || 'clang++' }}
-      WARNINGS_AS_ERRORS: ON
     strategy:
       fail-fast: false
       matrix:
@@ -62,8 +61,6 @@ jobs:
   windows:
     name: release / windows-latest / msvc
     runs-on: windows-latest
-    env:
-      WARNINGS_AS_ERRORS: ON
     steps:
       - uses: actions/checkout@v4
       - uses: conan-io/setup-conan@v1
@@ -86,7 +83,6 @@ jobs:
     env:
       CC: gcc
       CXX: g++
-      WARNINGS_AS_ERRORS: ON
     steps:
       - uses: actions/checkout@v4
       - uses: conan-io/setup-conan@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        preset: [release, sanitize]
+        preset: [debug, release, sanitize]
         compiler: [gcc, clang]
         exclude:
           - os: macos-latest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,19 +106,14 @@ function(enable_hardening target)
 
     target_compile_options(${target} PRIVATE -fstack-protector-strong)
 
-    # Fortified libc calls need optimization, so Debug (-O0) skips them. -U first:
-    # Ubuntu's gcc predefines _FORTIFY_SOURCE when optimizing, and redefining it is
-    # fatal under -Werror. Compile options rather than compile definitions to keep
-    # the -U/-D order. glibc supports level 3; Apple's libc caps at 2.
-    if(APPLE)
-        set(fortify_level 2)
-    else()
-        set(fortify_level 3)
-    endif()
+    # Fortified libc calls need optimization, so Debug (-O0) skips them. Level 2 on
+    # every platform for identical semantics across libcs (Apple's libc clamps
+    # anything higher to 2 anyway). -U first: Ubuntu's gcc predefines
+    # _FORTIFY_SOURCE=3 when optimizing, and redefining it is fatal under -Werror.
+    # Compile options rather than compile definitions to keep the -U/-D order.
     target_compile_options(
-        ${target}
-        PRIVATE
-            $<$<NOT:$<CONFIG:Debug>>:-U_FORTIFY_SOURCE;-D_FORTIFY_SOURCE=${fortify_level}>
+        ${target} PRIVATE
+        $<$<NOT:$<CONFIG:Debug>>:-U_FORTIFY_SOURCE;-D_FORTIFY_SOURCE=2>
     )
 
     if(CMAKE_SYSTEM_NAME STREQUAL "Linux")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ include(CTest)
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
-option(WARNINGS_AS_ERRORS "Treat warnings as errors" OFF)
+option(WARNINGS_AS_ERRORS "Treat warnings as errors" ON)
 option(ENABLE_SANITIZERS "Enable sanitizer instrumentation" OFF)
 option(ENABLE_COVERAGE "Enable code coverage instrumentation" OFF)
 option(ENABLE_HARDENING "Enable hardening compile and link flags" ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,8 +100,11 @@ function(enable_hardening target)
         return()
     endif()
 
+    # Unknown compilers build unhardened rather than failing configure: hardening is
+    # on by default, so a hard error here would block toolchains the user never asked
+    # to harden.
     if(NOT CMAKE_CXX_COMPILER_ID MATCHES "^(GNU|Clang|AppleClang)$")
-        message(FATAL_ERROR "Hardening requires MSVC, GCC, Clang, or AppleClang")
+        return()
     endif()
 
     target_compile_options(${target} PRIVATE -fstack-protector-strong)
@@ -123,13 +126,15 @@ function(enable_hardening target)
         target_link_options(
             ${target} PRIVATE -Wl,-z,relro -Wl,-z,now -Wl,-z,noexecstack
         )
-        if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(x86_64|AMD64)$")
-            # Intel CET; x86-only and not supported on Darwin.
-            target_compile_options(${target} PRIVATE -fcf-protection=full)
-        endif()
     endif()
-    if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(arm64|aarch64)$")
-        # BTI + pac-ret on AArch64.
+
+    # Control-flow integrity is arch-gated, not OS-gated: each flag is a hard error
+    # on the other architecture.
+    if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(x86_64|AMD64)$")
+        # Intel CET.
+        target_compile_options(${target} PRIVATE -fcf-protection=full)
+    elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^(arm64|aarch64)$")
+        # BTI + pac-ret.
         target_compile_options(${target} PRIVATE -mbranch-protection=standard)
     endif()
 endfunction()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 option(WARNINGS_AS_ERRORS "Treat warnings as errors" OFF)
 option(ENABLE_SANITIZERS "Enable sanitizer instrumentation" OFF)
 option(ENABLE_COVERAGE "Enable code coverage instrumentation" OFF)
+option(ENABLE_HARDENING "Enable hardening compile and link flags" ON)
 
 if(CMAKE_EXPORT_COMPILE_COMMANDS
    AND CMAKE_GENERATOR MATCHES "Ninja|Makefiles"
@@ -81,10 +82,68 @@ function(enable_coverage target)
     endif()
 endfunction()
 
+function(enable_hardening target)
+    # Instrumented builds skip hardening: _FORTIFY_SOURCE conflicts with the ASan
+    # interceptors, and coverage builds run at -O0 where glibc fortify warns (fatal
+    # under -Werror).
+    if(NOT ENABLE_HARDENING
+       OR ENABLE_SANITIZERS
+       OR ENABLE_COVERAGE
+    )
+        return()
+    endif()
+
+    if(MSVC)
+        # Control Flow Guard needs both compile and link; /GS is on by default.
+        target_compile_options(${target} PRIVATE /guard:cf)
+        target_link_options(${target} PRIVATE /guard:cf)
+        return()
+    endif()
+
+    if(NOT CMAKE_CXX_COMPILER_ID MATCHES "^(GNU|Clang|AppleClang)$")
+        message(FATAL_ERROR "Hardening requires MSVC, GCC, Clang, or AppleClang")
+    endif()
+
+    target_compile_options(${target} PRIVATE -fstack-protector-strong)
+
+    # Fortified libc calls need optimization, so Debug (-O0) skips them. -U first:
+    # Ubuntu's gcc predefines _FORTIFY_SOURCE when optimizing, and redefining it is
+    # fatal under -Werror. Compile options rather than compile definitions to keep
+    # the -U/-D order. glibc supports level 3; Apple's libc caps at 2.
+    if(APPLE)
+        set(fortify_level 2)
+    else()
+        set(fortify_level 3)
+    endif()
+    target_compile_options(
+        ${target}
+        PRIVATE
+            $<$<NOT:$<CONFIG:Debug>>:-U_FORTIFY_SOURCE;-D_FORTIFY_SOURCE=${fortify_level}>
+    )
+
+    if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+        target_compile_options(${target} PRIVATE -fstack-clash-protection)
+        # ELF-only link hardening (ld64 rejects -z): read-only relocations, immediate
+        # binding, non-executable stack.
+        target_link_options(
+            ${target} PRIVATE -Wl,-z,relro -Wl,-z,now -Wl,-z,noexecstack
+        )
+        if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(x86_64|AMD64)$")
+            # Intel CET; x86-only and not supported on Darwin.
+            target_compile_options(${target} PRIVATE -fcf-protection=full)
+        endif()
+    endif()
+    if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(arm64|aarch64)$")
+        # BTI + pac-ret on AArch64.
+        target_compile_options(${target} PRIVATE -mbranch-protection=standard)
+    endif()
+endfunction()
+
 function(enable_project_options target)
     enable_project_warnings(${target})
     enable_sanitizers(${target})
     enable_coverage(${target})
+    enable_hardening(${target})
 endfunction()
 
 # --- library ---------------------------------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,46 +97,17 @@ function(enable_hardening target)
         # Control Flow Guard needs both compile and link; /GS is on by default.
         target_compile_options(${target} PRIVATE /guard:cf)
         target_link_options(${target} PRIVATE /guard:cf)
-        return()
-    endif()
-
-    # Unknown compilers build unhardened rather than failing configure: hardening is
-    # on by default, so a hard error here would block toolchains the user never asked
-    # to harden.
-    if(NOT CMAKE_CXX_COMPILER_ID MATCHES "^(GNU|Clang|AppleClang)$")
-        return()
-    endif()
-
-    target_compile_options(${target} PRIVATE -fstack-protector-strong)
-
-    # Fortified libc calls need optimization, so Debug (-O0) skips them. Level 2 on
-    # every platform for identical semantics across libcs (Apple's libc clamps
-    # anything higher to 2 anyway). -U first: Ubuntu's gcc predefines
-    # _FORTIFY_SOURCE=3 when optimizing, and redefining it is fatal under -Werror.
-    # Compile options rather than compile definitions to keep the -U/-D order.
-    target_compile_options(
-        ${target} PRIVATE
-        $<$<NOT:$<CONFIG:Debug>>:-U_FORTIFY_SOURCE;-D_FORTIFY_SOURCE=2>
-    )
-
-    if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
-        target_compile_options(${target} PRIVATE -fstack-clash-protection)
-        # ELF-only link hardening (ld64 rejects -z): read-only relocations, immediate
-        # binding, non-executable stack.
-        target_link_options(
-            ${target} PRIVATE -Wl,-z,relro -Wl,-z,now -Wl,-z,noexecstack
+    elseif(CMAKE_CXX_COMPILER_ID MATCHES "^(GNU|Clang|AppleClang)$")
+        # Stack protector always; fortified libc calls only in optimized configs
+        # (fortify needs optimization, so Debug skips it). -U first: Ubuntu's gcc
+        # predefines _FORTIFY_SOURCE when optimizing, and redefining it is fatal
+        # under -Werror. Compile options, not definitions, to keep the -U/-D order.
+        target_compile_options(
+            ${target} PRIVATE -fstack-protector-strong
+            $<$<NOT:$<CONFIG:Debug>>:-U_FORTIFY_SOURCE;-D_FORTIFY_SOURCE=2>
         )
     endif()
-
-    # Control-flow integrity is arch-gated, not OS-gated: each flag is a hard error
-    # on the other architecture.
-    if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(x86_64|AMD64)$")
-        # Intel CET.
-        target_compile_options(${target} PRIVATE -fcf-protection=full)
-    elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^(arm64|aarch64)$")
-        # BTI + pac-ret.
-        target_compile_options(${target} PRIVATE -mbranch-protection=standard)
-    endif()
+    # Other compilers fall through and build unhardened.
 endfunction()
 
 function(enable_project_options target)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -10,41 +10,34 @@
   ],
   "configurePresets": [
     {
-      "name": "_warnings",
-      "hidden": true,
-      "cacheVariables": {
-        "WARNINGS_AS_ERRORS": "$env{WARNINGS_AS_ERRORS}"
-      }
-    },
-    {
       "name": "debug",
       "displayName": "Debug",
       "description": "Debug configuration backed by Conan's debug preset.",
-      "inherits": ["conan-debug", "_warnings"]
+      "inherits": "conan-debug"
     },
     {
       "name": "release",
       "displayName": "Release",
       "description": "Release configuration backed by Conan's release preset.",
-      "inherits": ["conan-release", "_warnings"]
+      "inherits": "conan-release"
     },
     {
       "name": "sanitize",
       "displayName": "Sanitizers (ASan + UBSan)",
       "description": "Debug configuration with combined ASan+UBSan instrumentation from the Conan sanitize profile.",
-      "inherits": ["conan-debug-addressundefinedbehavior", "_warnings"]
+      "inherits": "conan-debug-addressundefinedbehavior"
     },
     {
       "name": "sanitize-asan",
       "displayName": "Sanitizers (ASan)",
       "description": "Debug configuration with AddressSanitizer instrumentation from the Conan sanitize-asan profile.",
-      "inherits": ["conan-debug-address", "_warnings"]
+      "inherits": "conan-debug-address"
     },
     {
       "name": "sanitize-ubsan",
       "displayName": "Sanitizers (UBSan)",
       "description": "Debug configuration with UndefinedBehaviorSanitizer instrumentation from the Conan sanitize-ubsan profile.",
-      "inherits": ["conan-debug-undefinedbehavior", "_warnings"]
+      "inherits": "conan-debug-undefinedbehavior"
     },
     {
       "name": "coverage",

--- a/README.md
+++ b/README.md
@@ -174,6 +174,9 @@ project leaves it at the default `ON`, so `make debug`, `make release`, `make sa
 The Conan-generated `conan-*` presets are internal implementation details and are not the public
 interface for developers or CI.
 
+Warnings are errors by default (`WARNINGS_AS_ERRORS`, default `ON`) in every preset, locally and
+in CI. Relax it for a single build tree with `cmake --preset <name> -DWARNINGS_AS_ERRORS=OFF`.
+
 ## Dependency lock file
 
 `conan.lock` pins the exact dependency graph for reproducible builds. To update dependencies:

--- a/README.md
+++ b/README.md
@@ -212,6 +212,24 @@ override with `make coverage-report COVERAGE_FAIL_UNDER=80`). `gcov` and `llvm-c
 count lines differently (gcov reports lower), so the floor tracks the gcov figure
 so both paths pass.
 
+## Hardening
+
+First-party targets build with hardening flags by default (`ENABLE_HARDENING`, default `ON`;
+disable with `-DENABLE_HARDENING=OFF` on any configure preset):
+
+- GCC/Clang/AppleClang, all configurations: `-fstack-protector-strong`; AArch64 additionally
+  gets `-mbranch-protection=standard` (BTI + pac-ret).
+- Optimized configurations add `-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3` (glibc; level 2 on
+  Apple's libc). Debug skips fortification because it requires optimization.
+- Linux adds `-fstack-clash-protection`, `-fcf-protection=full` on x86_64, and the ELF link
+  flags `-Wl,-z,relro -Wl,-z,now -Wl,-z,noexecstack`.
+- MSVC adds `/guard:cf` (Control Flow Guard) at compile and link.
+
+Sanitizer and coverage builds omit hardening: `_FORTIFY_SOURCE` conflicts with the ASan
+interceptors, and coverage builds run at `-O0` where glibc fortification warns. Like the
+warning options, hardening covers first-party code only; dependency binaries from the Conan
+cache are not rebuilt with these flags.
+
 ## Install
 
 `cmake --install` installs the application binary to `<prefix>/bin`. Only the executable is

--- a/README.md
+++ b/README.md
@@ -222,8 +222,8 @@ disable with `-DENABLE_HARDENING=OFF` on any configure preset):
 
 - GCC/Clang/AppleClang, all configurations: `-fstack-protector-strong`; AArch64 additionally
   gets `-mbranch-protection=standard` (BTI + pac-ret).
-- Optimized configurations add `-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3` (glibc; level 2 on
-  Apple's libc). Debug skips fortification because it requires optimization.
+- Optimized configurations add `-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2` on every platform.
+  Debug skips fortification because it requires optimization.
 - Linux adds `-fstack-clash-protection`, `-fcf-protection=full` on x86_64, and the ELF link
   flags `-Wl,-z,relro -Wl,-z,now -Wl,-z,noexecstack`.
 - MSVC adds `/guard:cf` (Control Flow Guard) at compile and link.

--- a/README.md
+++ b/README.md
@@ -220,13 +220,15 @@ so both paths pass.
 First-party targets build with hardening flags by default (`ENABLE_HARDENING`, default `ON`;
 disable with `-DENABLE_HARDENING=OFF` on any configure preset):
 
-- GCC/Clang/AppleClang, all configurations: `-fstack-protector-strong`; AArch64 additionally
-  gets `-mbranch-protection=standard` (BTI + pac-ret).
+- GCC/Clang/AppleClang, all configurations: `-fstack-protector-strong`, plus control-flow
+  integrity by architecture: `-fcf-protection=full` (Intel CET) on x86_64,
+  `-mbranch-protection=standard` (BTI + pac-ret) on AArch64.
 - Optimized configurations add `-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2` on every platform.
   Debug skips fortification because it requires optimization.
-- Linux adds `-fstack-clash-protection`, `-fcf-protection=full` on x86_64, and the ELF link
-  flags `-Wl,-z,relro -Wl,-z,now -Wl,-z,noexecstack`.
+- Linux adds `-fstack-clash-protection` and the ELF link flags
+  `-Wl,-z,relro -Wl,-z,now -Wl,-z,noexecstack`.
 - MSVC adds `/guard:cf` (Control Flow Guard) at compile and link.
+- Other compilers build unhardened rather than failing to configure.
 
 Sanitizer and coverage builds omit hardening: `_FORTIFY_SOURCE` conflicts with the ASan
 interceptors, and coverage builds run at `-O0` where glibc fortification warns. Like the

--- a/README.md
+++ b/README.md
@@ -220,14 +220,10 @@ so both paths pass.
 First-party targets build with hardening flags by default (`ENABLE_HARDENING`, default `ON`;
 disable with `-DENABLE_HARDENING=OFF` on any configure preset):
 
-- GCC/Clang/AppleClang, all configurations: `-fstack-protector-strong`, plus control-flow
-  integrity by architecture: `-fcf-protection=full` (Intel CET) on x86_64,
-  `-mbranch-protection=standard` (BTI + pac-ret) on AArch64.
-- Optimized configurations add `-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2` on every platform.
-  Debug skips fortification because it requires optimization.
-- Linux adds `-fstack-clash-protection` and the ELF link flags
-  `-Wl,-z,relro -Wl,-z,now -Wl,-z,noexecstack`.
-- MSVC adds `/guard:cf` (Control Flow Guard) at compile and link.
+- GCC/Clang/AppleClang: `-fstack-protector-strong` in every configuration; optimized
+  configurations add `-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2` (Debug skips fortification
+  because it requires optimization).
+- MSVC: `/guard:cf` (Control Flow Guard) at compile and link.
 - Other compilers build unhardened rather than failing to configure.
 
 Sanitizer and coverage builds omit hardening: `_FORTIFY_SOURCE` conflicts with the ASan


### PR DESCRIPTION
Follow-ups from the project evaluation, one commit each.

## Debug preset in CI

The build matrix gains `debug`, adding three jobs (ubuntu gcc/clang, macos clang). Previously no job built or tested the plain Debug configuration, so `-O0`/assert-only breakage could land unnoticed. No other workflow changes needed: `make bootstrap` already installs the debug graph and the install-verify step was already release-gated.

## Hardening flags on by default

New `ENABLE_HARDENING` option (default `ON`) and `enable_hardening()` in `CMakeLists.txt`, following the existing per-target option-function pattern. Flags by scope:

- GCC/Clang/AppleClang: `-fstack-protector-strong` in every config; non-Debug configs add `-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2` (`-U` first because Ubuntu's gcc predefines fortify when optimizing, which would be a fatal redefinition under `-Werror`; level 2 everywhere for identical semantics across libcs)
- MSVC: `/guard:cf` at compile and link
- Other compilers fall through and build unhardened rather than failing configure

Review iterations on this branch trimmed the initial flag set (stack-clash, ELF `-z` link flags, CET, BTI) down to this portable core

Sanitizer and coverage builds skip hardening (`_FORTIFY_SOURCE` conflicts with ASan interceptors; coverage runs at `-O0` where glibc fortify warns). First-party targets only; Conan dependency binaries are unchanged.

## WARNINGS_AS_ERRORS defaults to ON

The option default flips to `ON`, and the `_warnings` hidden preset plus the CI `WARNINGS_AS_ERRORS: ON` env plumbing are removed: with an unset env var, `$env{WARNINGS_AS_ERRORS}` expanded to an empty string in the cache, which would have silently forced the option OFF for local builds and defeated the new default. Opt-out is `-DWARNINGS_AS_ERRORS=OFF` (documented in the README). Note for existing clones: a previously configured build tree may carry a stale cached value; `make clean` or `cmake --preset <name> --fresh` picks up the new default.

## Verification

Local (AppleClang arm64): `make debug`, `make release`, `make sanitize` all pass with the new defaults; `nm` shows `__stack_chk_guard` in the release binary; `compile_commands.json` shows fortify=2 and branch-protection on release TUs, no fortify in debug (config genex), and `-Werror` present after a `--fresh` configure with no env var. CI on this PR exercises fortify=3/stack-clash/CET/RELRO under gcc and clang on Linux, `/guard:cf` on MSVC, and the three new debug jobs.
