### PR TITLE
build: cache first-party compiles with ccache

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,8 @@ jobs:
     env:
       CC: ${{ matrix.compiler == 'gcc' && 'gcc' || 'clang' }}
       CXX: ${{ matrix.compiler == 'gcc' && 'g++' || 'clang++' }}
+      CCACHE_DIR: ${{ github.workspace }}/.ccache
+      CCACHE_MAXSIZE: 200M
     strategy:
       fail-fast: false
       matrix:
@@ -42,11 +44,23 @@ jobs:
         with:
           version: ${{ env.CONAN_VERSION }}
           cache_packages: true
+      - name: Install ccache
+        run: ${{ runner.os == 'macOS' && 'brew install ccache' || 'sudo apt-get install -y ccache' }}
+      # Rolling cache key: actions/cache saves only on an exact-key miss, so the run_id
+      # suffix makes every run save an updated cache while restore-keys warm-starts
+      # from the newest previous one.
+      - uses: actions/cache@v4
+        with:
+          path: .ccache
+          key: ccache-${{ matrix.os }}-${{ matrix.compiler }}-${{ matrix.preset }}-${{ github.run_id }}
+          restore-keys: ccache-${{ matrix.os }}-${{ matrix.compiler }}-${{ matrix.preset }}-
       - run: make lock-check
       - run: make bootstrap
       - if: matrix.preset == 'sanitize'
         run: make bootstrap-sanitize
       - run: make ${{ matrix.preset }}
+      - name: ccache stats
+        run: ccache -sv
       # Install the application to a throwaway prefix and run it, verifying the install() rule.
       - name: Verify install (release)
         if: matrix.preset == 'release'
@@ -83,12 +97,20 @@ jobs:
     env:
       CC: gcc
       CXX: g++
+      CCACHE_DIR: ${{ github.workspace }}/.ccache
+      CCACHE_MAXSIZE: 200M
     steps:
       - uses: actions/checkout@v4
       - uses: conan-io/setup-conan@v1
         with:
           version: ${{ env.CONAN_VERSION }}
           cache_packages: true
+      - run: sudo apt-get install -y ccache
+      - uses: actions/cache@v4
+        with:
+          path: .ccache
+          key: ccache-coverage-${{ github.run_id }}
+          restore-keys: ccache-coverage-
       - run: python3 -m pip install --break-system-packages --user gcovr
       - run: make bootstrap
       # Builds, runs the suite, and fails if line coverage drops below the floor.

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ stable across toolchain changes.
 - [CMake](https://cmake.org/download/) 3.25+ (for workflow presets)
 - [Conan](https://docs.conan.io/2/installation.html) 2.25+ (for the `CMakeConfigDeps` generator)
 - [Ninja](https://ninja-build.org/) (optional, Unix only; GNU Make is used when absent)
+- [ccache](https://ccache.dev/) (optional; used automatically for first-party targets when on
+  PATH — not with the Visual Studio generator, which ignores compiler launchers)
 - A compiler and standard library with working C++23 support
   - [GCC](https://gcc.gnu.org/) 13+
   - [LLVM Clang](https://llvm.org/) 17+

--- a/conanfile.py
+++ b/conanfile.py
@@ -91,4 +91,10 @@ class CppBoilerplateConan(ConanFile):
         # Flow the Conan option into CMake: with tests disabled, BUILD_TESTING (from
         # include(CTest)) is off and find_package(GTest) is never reached.
         tc.cache_variables["BUILD_TESTING"] = bool(self.options.with_tests)
+        # Compiler caching for first-party targets when ccache is on PATH (same
+        # optional-tool probe as the ninja check above); dependency binaries come from
+        # the Conan cache and don't need it. The Visual Studio generator ignores
+        # CMAKE_CXX_COMPILER_LAUNCHER, so skip the probe on Windows.
+        if self.settings.os != "Windows" and shutil.which("ccache"):
+            tc.cache_variables["CMAKE_CXX_COMPILER_LAUNCHER"] = "ccache"
         tc.generate()


### PR DESCRIPTION
Next item from the evaluation backlog: dependencies are cached by setup-conan's package cache, but first-party sources recompiled from scratch on every CI run (and after every local `make clean`).

## Wiring

`generate()` in `conanfile.py` sets `CMAKE_CXX_COMPILER_LAUNCHER=ccache` as a toolchain cache variable when `ccache` is on PATH — the same optional-tool probe as the existing ninja check, so there is no hard dependency: without ccache nothing changes. Verified against the Conan 2.29.1 source that CMakeToolchain has no dedicated launcher conf, making `cache_variables` the right seam. The probe is skipped on Windows because the Visual Studio generator ignores compiler launchers; the lint job is untouched because it never compiles. Scope is first-party targets only — Conan-built dependency binaries stay covered by the package cache.

## CI

The build-matrix and coverage jobs install ccache, set `CCACHE_DIR` to a workspace path (Linux and macOS defaults differ) with a 200M cap, and persist the directory via first-party `actions/cache` (consistent with this repo's avoidance of third-party actions). The key carries a `github.run_id` suffix with a prefix `restore-keys`: `actions/cache` saves only on an exact-key miss, so every run saves an updated cache while warm-starting from the newest previous one. A post-build `ccache -sv` step surfaces the hit rate in the log.

## Verification

Local (AppleClang, ccache via brew): cold `make debug` shows 3/3 cacheable misses and `CMAKE_CXX_COMPILER_LAUNCHER=ccache` in the CMake cache; after deleting the build objects, the rebuild scores 3/3 direct hits. This PR's first CI run is cold; the `ccache stats` step on a subsequent run (or re-run) should show hits, proving the cache round-trips through actions/cache.