### PR TITLE
build: guard settings_user.yml install and note lock-check scope

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,15 @@ $(STAMP_DIR)/debug.stamp $(STAMP_DIR)/release.stamp: conan.lock
 $(STAMP_DIR)/sanitize.stamp: conan.lock conan/settings_user.yml profiles/sanitize profiles/sanitize-common
 	echo "Installing Conan dependencies (sanitize)..."
 	mkdir -p $(STAMP_DIR)
+	# conan config install copies settings_user.yml into the Conan home, which would
+	# silently overwrite a settings_user.yml another project put there. Refuse when a
+	# different one exists; the file is small enough to merge by hand.
+	installed="$$(conan config home)/settings_user.yml"; \
+	if [ -f "$$installed" ] && ! cmp -s conan/settings_user.yml "$$installed"; then \
+		echo "ERROR: $$installed exists and differs from conan/settings_user.yml."; \
+		echo "Merge conan/settings_user.yml into it by hand (or remove it), then rerun."; \
+		exit 1; \
+	fi
 	conan config install conan/
 	conan install . -pr=profiles/sanitize --build=missing --lockfile=conan.lock
 	touch $@
@@ -194,6 +203,9 @@ lock: ## Force-regenerate conan.lock from conanfile.py
 	echo "Regenerating conan.lock..."
 	conan lock create . -pr=$(CONAN_PROFILE) --lockfile-clean --lockfile-out=conan.lock
 
+# Scope: validates the graph resolved by the default profile only. If requirements()
+# ever gains platform-conditional requires (the pattern its comment advertises), this
+# check needs to run once per platform profile to cover the full graph.
 .PHONY: lock-check
 lock-check: ## Fail if conan.lock is out of date with conanfile.py (used by CI)
 	tmp=$$(mktemp); \

--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,9 @@ COLOR_RESET := \033[0m
 # Fail the recipe with a red ERROR message on stderr: $(DIE) "message". %b expands
 # \n for multi-line messages. A sh -c one-liner (message as shell arg $0) rather than
 # a $(call ...) macro because call splits its arguments on the commas messages contain.
-# The subprocess cannot exit the recipe shell mid-sequence, so keep it the last
-# command of its branch; its status then fails the recipe line.
+# The subprocess cannot exit the recipe shell itself, so a call site must either end
+# its recipe line (make checks each line's status) or run under `set -e` so the shell
+# stops at the failed status; every site here does one or the other.
 DIE := sh -c 'printf "$(COLOR_RED)ERROR:$(COLOR_RESET) %b\n" "$$0" >&2; exit 1'
 
 # Coverage uses two toolchains: Clang builds emit source-based profiles read by
@@ -214,13 +215,13 @@ lock: ## Force-regenerate conan.lock from conanfile.py
 # check needs to run once per platform profile to cover the full graph.
 .PHONY: lock-check
 lock-check: ## Fail if conan.lock is out of date with conanfile.py (used by CI)
-	tmp=$$(mktemp); \
+	set -e; tmp=$$(mktemp); trap 'rm -f "$$tmp"' EXIT; \
 	conan lock create . -pr=$(CONAN_PROFILE) --lockfile-clean --lockfile-out=$$tmp >/dev/null 2>&1 \
-		|| { rm -f $$tmp; $(DIE) "conan lock create failed"; }; \
+		|| $(DIE) "conan lock create failed"; \
 	if diff conan.lock $$tmp >/dev/null; then \
-		rm -f $$tmp; echo "conan.lock is up to date"; \
+		echo "conan.lock is up to date"; \
 	else \
-		diff conan.lock $$tmp || true; rm -f $$tmp; \
+		diff conan.lock $$tmp || true; \
 		$(DIE) "conan.lock is stale; run 'make lock' and commit the result"; \
 	fi
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,15 @@
 UNAME_S := $(shell uname -s)
 
 COLOR_CYAN := \033[36m
+COLOR_RED := \033[31m
 COLOR_RESET := \033[0m
+
+# Fail the recipe with a red ERROR message on stderr: $(DIE) "message". %b expands
+# \n for multi-line messages. A sh -c one-liner (message as shell arg $0) rather than
+# a $(call ...) macro because call splits its arguments on the commas messages contain.
+# The subprocess cannot exit the recipe shell mid-sequence, so keep it the last
+# command of its branch; its status then fails the recipe line.
+DIE := sh -c 'printf "$(COLOR_RED)ERROR:$(COLOR_RESET) %b\n" "$$0" >&2; exit 1'
 
 # Coverage uses two toolchains: Clang builds emit source-based profiles read by
 # llvm-cov; GCC builds emit gcov data read by gcovr. coverage-report auto-selects
@@ -61,7 +69,7 @@ FORMAT_SOURCES = $(shell find include src tests -type f \( -name '*.hpp' -o -nam
 TIDY_SOURCES = $(shell find src tests -type f -name '*.cpp')
 
 define require-tool
-	command -v $(1) >/dev/null || { echo "$(1) not found"; exit 1; }
+	command -v $(1) >/dev/null || $(DIE) "$(1) not found"
 endef
 
 # ---------------------------------------------------------------------------
@@ -93,9 +101,7 @@ $(STAMP_DIR)/sanitize.stamp: conan.lock conan/settings_user.yml profiles/sanitiz
 	# different one exists; the file is small enough to merge by hand.
 	installed="$$(conan config home)/settings_user.yml"; \
 	if [ -f "$$installed" ] && ! cmp -s conan/settings_user.yml "$$installed"; then \
-		echo "ERROR: $$installed exists and differs from conan/settings_user.yml."; \
-		echo "Merge conan/settings_user.yml into it by hand (or remove it), then rerun."; \
-		exit 1; \
+		$(DIE) "$$installed exists and differs from conan/settings_user.yml.\nMerge conan/settings_user.yml into it by hand (or remove it), then rerun."; \
 	fi
 	conan config install conan/
 	conan install . -pr=profiles/sanitize --build=missing --lockfile=conan.lock
@@ -210,12 +216,12 @@ lock: ## Force-regenerate conan.lock from conanfile.py
 lock-check: ## Fail if conan.lock is out of date with conanfile.py (used by CI)
 	tmp=$$(mktemp); \
 	conan lock create . -pr=$(CONAN_PROFILE) --lockfile-clean --lockfile-out=$$tmp >/dev/null 2>&1 \
-		|| { echo "ERROR: conan lock create failed"; rm -f $$tmp; exit 1; }; \
+		|| { rm -f $$tmp; $(DIE) "conan lock create failed"; }; \
 	if diff conan.lock $$tmp >/dev/null; then \
 		rm -f $$tmp; echo "conan.lock is up to date"; \
 	else \
-		echo "ERROR: conan.lock is stale; run 'make lock' and commit the result"; \
-		diff conan.lock $$tmp || true; rm -f $$tmp; exit 1; \
+		diff conan.lock $$tmp || true; rm -f $$tmp; \
+		$(DIE) "conan.lock is stale; run 'make lock' and commit the result"; \
 	fi
 
 .PHONY: clean


### PR DESCRIPTION
Two review-residue items from the project evaluation, both in the `Makefile`.

## Clobber guard for `conan config install`

`make bootstrap-sanitize` runs `conan config install conan/`, which copies `settings_user.yml` into the Conan home — silently overwriting a `settings_user.yml` that another project may have installed there with its own custom subsettings, breaking that project's builds later. The sanitize stamp rule now resolves the home via `conan config home` first and:

- installs normally when no file exists there,
- installs when the existing file is identical (no-op),
- fails with a merge-by-hand message when the existing file differs.

Verified all three cases against a temp `CONAN_HOME`, plus a real `make bootstrap-sanitize` through the guarded rule (identical case) and the sanitize CI jobs exercise the absent case from scratch.

## lock-check scope note

Comment on `lock-check` stating it validates the default-profile dependency graph only. The `requirements()` comment in `conanfile.py` advertises platform-conditional requires as the reason for the method form; the moment someone adds one, a single-profile lock-check stops covering the full graph and needs per-platform runs. Comment-only; `make lock-check` still green.



## DIE helper

All Makefile error exits (`require-tool`, the guard above, both `lock-check` branches) now share a `DIE` helper that prints a red `ERROR:` to stderr and fails the recipe. It is a `sh -c` one-liner taking the message as a shell argument rather than a `$(call ...)` macro, because `call` splits arguments on the commas the messages contain; as a subprocess it must be the last command of its branch, which every site satisfies. All four failure paths exercised locally.
