### PR TITLE
feat: CLI11 command line, tested error path, and single-tool coverage

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,13 +1,11 @@
 FormatStyle: file
 WarningsAsErrors: >
   bugprone-*,
-  clang-analyzer-*,
   performance-*,
   -performance-avoid-endl
 HeaderFilterRegex: '^(include|src|tests)/'
 
 Checks: >
-  clang-analyzer-*,
   boost-*,
   bugprone-*,
   google-build-explicit-make-pair,

--- a/.cmake-format.yaml
+++ b/.cmake-format.yaml
@@ -1,9 +1,13 @@
-line_width: 100
-tab_size: 4
-
+# Configures both cmake-format and cmake-lint (cmakelang).
 format:
+  line_width: 100
+  tab_size: 4
   dangle_parens: true
   separate_ctrl_name_with_space: false
   separate_fn_name_with_space: false
   command_case: lower
   keyword_case: upper
+
+lint:
+  # C0111: helper functions here are one screen long; no mandatory docstrings.
+  disabled_codes: [C0111]

--- a/.cmakelintrc
+++ b/.cmakelintrc
@@ -1,0 +1,5 @@
+# cmakelint (github.com/cmake-lint/cmake-lint). Layout is owned by cmake-format
+# (.cmake-format.yaml): line width 100, and the 2-space indent heuristic is off
+# because it fights cmake-format's continuation alignment.
+filter=-whitespace/indent
+linelength=100

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
-# 3.25 is the floor bound by the features this template uses: workflow presets and
-# CMakePresets schema v6 (3.25), COMPILE_WARNING_AS_ERROR (3.24), cxx_std_23 (3.20).
+# 3.25 is the floor bound by the features this template uses: workflow presets and CMakePresets
+# schema v6 (3.25), COMPILE_WARNING_AS_ERROR (3.24), cxx_std_23 (3.20).
 cmake_minimum_required(VERSION 3.25)
 
 project(
@@ -15,7 +15,6 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 option(WARNINGS_AS_ERRORS "Treat warnings as errors" ON)
-option(ENABLE_SANITIZERS "Enable sanitizer instrumentation" OFF)
 option(ENABLE_COVERAGE "Enable code coverage instrumentation" OFF)
 option(ENABLE_HARDENING "Enable hardening compile and link flags" ON)
 
@@ -30,6 +29,7 @@ if(CMAKE_EXPORT_COMPILE_COMMANDS
 endif()
 
 find_package(spdlog CONFIG REQUIRED)
+find_package(CLI11 CONFIG REQUIRED)
 
 function(enable_project_warnings target)
     if(MSVC)
@@ -43,39 +43,13 @@ function(enable_project_warnings target)
     endif()
 endfunction()
 
-function(enable_sanitizers target)
-    if(NOT ENABLE_SANITIZERS)
-        return()
-    endif()
-
-    if(MSVC)
-        # MSVC ships AddressSanitizer; UndefinedBehaviorSanitizer is not available.
-        target_compile_options(${target} PRIVATE /fsanitize=address)
-    elseif(CMAKE_CXX_COMPILER_ID MATCHES "^(GNU|Clang|AppleClang)$")
-        target_compile_options(
-            ${target} PRIVATE -fsanitize=address,undefined -fno-sanitize-recover=all
-                              -fno-omit-frame-pointer
-        )
-        target_link_options(${target} PRIVATE -fsanitize=address,undefined)
-    else()
-        message(FATAL_ERROR "Sanitizers require MSVC, GCC, Clang, or AppleClang")
-    endif()
-endfunction()
-
 function(enable_coverage target)
     if(NOT ENABLE_COVERAGE)
         return()
     endif()
 
-    if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-        # Clang and AppleClang: source-based coverage, read by llvm-cov.
-        target_compile_options(${target} PRIVATE -O0 -g -fprofile-instr-generate
-                                                 -fcoverage-mapping
-        )
-        target_link_options(${target} PRIVATE -fprofile-instr-generate)
-    elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-        # GCC: gcov-based coverage, read by gcovr.
-        target_compile_options(${target} PRIVATE -O0 -g --coverage)
+    if(CMAKE_CXX_COMPILER_ID MATCHES "^(GNU|Clang|AppleClang)$")
+        target_compile_options(${target} PRIVATE --coverage)
         target_link_options(${target} PRIVATE --coverage)
     else()
         message(FATAL_ERROR "Coverage requires GCC, Clang, or AppleClang")
@@ -83,13 +57,7 @@ function(enable_coverage target)
 endfunction()
 
 function(enable_hardening target)
-    # Instrumented builds skip hardening: _FORTIFY_SOURCE conflicts with the ASan
-    # interceptors, and coverage builds run at -O0 where glibc fortify warns (fatal
-    # under -Werror).
-    if(NOT ENABLE_HARDENING
-       OR ENABLE_SANITIZERS
-       OR ENABLE_COVERAGE
-    )
+    if(NOT ENABLE_HARDENING)
         return()
     endif()
 
@@ -98,13 +66,13 @@ function(enable_hardening target)
         target_compile_options(${target} PRIVATE /guard:cf)
         target_link_options(${target} PRIVATE /guard:cf)
     elseif(CMAKE_CXX_COMPILER_ID MATCHES "^(GNU|Clang|AppleClang)$")
-        # Stack protector always; fortified libc calls only in optimized configs
-        # (fortify needs optimization, so Debug skips it). -U first: Ubuntu's gcc
-        # predefines _FORTIFY_SOURCE when optimizing, and redefining it is fatal
-        # under -Werror. Compile options, not definitions, to keep the -U/-D order.
+        # Stack protector always; fortified libc calls only in optimized configs (fortify needs
+        # optimization, so Debug skips it). -U first: Ubuntu's gcc predefines _FORTIFY_SOURCE when
+        # optimizing, and redefining it is fatal under -Werror. Compile options, not definitions, to
+        # keep the -U/-D order.
         target_compile_options(
             ${target} PRIVATE -fstack-protector-strong
-            $<$<NOT:$<CONFIG:Debug>>:-U_FORTIFY_SOURCE;-D_FORTIFY_SOURCE=2>
+                              $<$<NOT:$<CONFIG:Debug>>:-U_FORTIFY_SOURCE;-D_FORTIFY_SOURCE=2>
         )
     endif()
     # Other compilers fall through and build unhardened.
@@ -112,23 +80,22 @@ endfunction()
 
 function(enable_project_options target)
     enable_project_warnings(${target})
-    enable_sanitizers(${target})
     enable_coverage(${target})
     enable_hardening(${target})
 endfunction()
 
 # --- library ---------------------------------------------------------------
-# Non-main code lives in a library so the application and the tests link the same
-# artifact instead of recompiling sources. Include dirs and the language standard
-# are PUBLIC so both consumers inherit them.
+# Non-main code lives in a library so the application and the tests link the same artifact instead
+# of recompiling sources. Include dirs and the language standard are PUBLIC so both consumers
+# inherit them.
 add_library(cpp_boilerplate_lib STATIC src/split.cpp)
 target_include_directories(cpp_boilerplate_lib PUBLIC ${PROJECT_SOURCE_DIR}/include)
 target_compile_features(cpp_boilerplate_lib PUBLIC cxx_std_23)
 enable_project_options(cpp_boilerplate_lib)
 
 # --- application -----------------------------------------------------------
-# Generate a version header from the project() version (the single source of truth; the Conan
-# recipe reads the same value) and expose it to the application only.
+# Generate a version header from the project() version (the single source of truth; the Conan recipe
+# reads the same value) and expose it to the application only.
 configure_file(
     ${PROJECT_SOURCE_DIR}/cmake/version.hpp.in
     ${PROJECT_BINARY_DIR}/generated/cpp_boilerplate/version.hpp @ONLY
@@ -136,11 +103,11 @@ configure_file(
 
 add_executable(cpp_boilerplate src/main.cpp)
 target_include_directories(cpp_boilerplate PRIVATE ${PROJECT_BINARY_DIR}/generated)
-target_link_libraries(cpp_boilerplate PRIVATE cpp_boilerplate_lib spdlog::spdlog)
+target_link_libraries(cpp_boilerplate PRIVATE cpp_boilerplate_lib spdlog::spdlog CLI11::CLI11)
 enable_project_options(cpp_boilerplate)
 
-# Install only the application binary. The static library is an internal build artifact,
-# not a public deliverable, so it is deliberately not installed or exported.
+# Install only the application binary. The static library is an internal build artifact, not a
+# public deliverable, so it is deliberately not installed or exported.
 include(GNUInstallDirs)
 install(TARGETS cpp_boilerplate RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 
@@ -148,24 +115,28 @@ install(TARGETS cpp_boilerplate RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 if(BUILD_TESTING)
     find_package(GTest CONFIG REQUIRED)
     include(GoogleTest)
-    add_executable(split_test tests/split_test.cpp)
-    target_link_libraries(split_test PRIVATE cpp_boilerplate_lib GTest::gtest_main)
-    enable_project_options(split_test)
+    add_executable(cpp_boilerplate_test tests/split_test.cpp)
+    target_link_libraries(cpp_boilerplate_test PRIVATE cpp_boilerplate_lib GTest::gtest_main)
+    enable_project_options(cpp_boilerplate_test)
 
-    # Each test process writes its own raw profile (%p pid, %m binary id) so the
-    # source-based coverage data from all tests can be merged. Harmless for the
-    # non-coverage presets, whose binaries are not instrumented.
-    set(coverage_profile "LLVM_PROFILE_FILE=${CMAKE_BINARY_DIR}/profraw/%p-%m.profraw")
+    gtest_discover_tests(cpp_boilerplate_test DISCOVERY_MODE PRE_TEST)
 
-    gtest_discover_tests(split_test DISCOVERY_MODE PRE_TEST
-                         PROPERTIES ENVIRONMENT "${coverage_profile}"
-    )
-
-    # Smoke test: the application binary runs to completion and exits cleanly.
-    # Complements the unit tests by exercising src/main.cpp, including under the
-    # sanitizer and coverage presets.
+    # Smoke tests: exercise the application binary end to end — the normal run, the --version and
+    # --help branches, and the error path (unknown argument -> nonzero exit). Together they cover
+    # all of src/main.cpp, including under the sanitizer and coverage presets.
     add_test(NAME AppTest.RunsToCompletion COMMAND cpp_boilerplate)
-    set_tests_properties(AppTest.RunsToCompletion PROPERTIES
-                         PASS_REGULAR_EXPRESSION "done" ENVIRONMENT "${coverage_profile}"
+    set_tests_properties(AppTest.RunsToCompletion PROPERTIES PASS_REGULAR_EXPRESSION "done")
+
+    add_test(NAME AppTest.PrintsVersion COMMAND cpp_boilerplate --version)
+    set_tests_properties(
+        AppTest.PrintsVersion PROPERTIES PASS_REGULAR_EXPRESSION "${PROJECT_VERSION}"
     )
+
+    add_test(NAME AppTest.PrintsHelp COMMAND cpp_boilerplate --help)
+    set_tests_properties(AppTest.PrintsHelp PROPERTIES PASS_REGULAR_EXPRESSION "OPTIONS")
+
+    # WILL_FAIL inverts the exit-code check: the test passes because the app exits nonzero on an
+    # unknown argument.
+    add_test(NAME AppTest.RejectsUnknownArgument COMMAND cpp_boilerplate --bogus)
+    set_tests_properties(AppTest.RejectsUnknownArgument PROPERTIES WILL_FAIL TRUE)
 endif()

--- a/Makefile
+++ b/Makefile
@@ -12,24 +12,19 @@ COLOR_RESET := \033[0m
 # stops at the failed status; every site here does one or the other.
 DIE := sh -c 'printf "$(COLOR_RED)ERROR:$(COLOR_RESET) %b\n" "$$0" >&2; exit 1'
 
-# Coverage uses two toolchains: Clang builds emit source-based profiles read by
-# llvm-cov; GCC builds emit gcov data read by gcovr. coverage-report auto-selects
-# based on which artifacts the build produced.
+# Both compilers emit gcov-format data (--coverage), reported by gcovr. The gcov
+# tool must match the compiler: gcc's data needs gcov, clang's needs llvm-cov gcov.
+# Darwin implies AppleClang (xcrun resolves the matching Xcode tool); clang-on-Linux
+# users override with GCOV_EXECUTABLE="llvm-cov gcov".
 ifeq ($(UNAME_S),Darwin)
 HOMEBREW_LLVM_PREFIX := $(shell brew --prefix llvm 2>/dev/null)
 ifneq ($(HOMEBREW_LLVM_PREFIX),)
 export PATH := $(HOMEBREW_LLVM_PREFIX)/bin:$(PATH)
 endif
-# xcrun resolves the LLVM tools from the active Xcode toolchain, matching the
-# AppleClang that produced the .profraw files.
-LLVM_PROFDATA ?= xcrun llvm-profdata
-LLVM_COV ?= xcrun llvm-cov
+GCOV_EXECUTABLE ?= xcrun llvm-cov gcov
 else
-LLVM_PROFDATA ?= llvm-profdata
-LLVM_COV ?= llvm-cov
-endif
-
 GCOV_EXECUTABLE ?= gcov
+endif
 
 .DEFAULT_GOAL := help
 
@@ -57,15 +52,7 @@ CONAN_STAMP_coverage := debug
 # ---------------------------------------------------------------------------
 STAMP_DIR := build/.stamps
 COVERAGE_DIR := build/coverage
-# Floor is shared by both report paths. gcov and llvm-cov count lines differently
-# (gcov 74.1%, llvm-cov 86.1% for the same code on CI), so it tracks the lower
-# gcov figure: 74 is the tightest integer the gcov path clears (75 would fail).
-COVERAGE_FAIL_UNDER ?= 74
-COVERAGE_PROFRAW := $(COVERAGE_DIR)/profraw
-COVERAGE_PROFDATA := $(COVERAGE_DIR)/coverage.profdata
-# Report merged coverage for both binaries, restricted to first-party sources.
-COVERAGE_OBJECTS := $(COVERAGE_DIR)/cpp_boilerplate -object $(COVERAGE_DIR)/split_test
-COVERAGE_SOURCES := $(CURDIR)/src $(CURDIR)/include
+COVERAGE_FAIL_UNDER ?= 100
 FORMAT_SOURCES = $(shell find include src tests -type f \( -name '*.hpp' -o -name '*.cpp' \))
 TIDY_SOURCES = $(shell find src tests -type f -name '*.cpp')
 
@@ -145,34 +132,11 @@ debug release sanitize coverage: %: $(STAMP_DIR)/$$(CONAN_STAMP_%).stamp
 # ---------------------------------------------------------------------------
 .PHONY: coverage-data-clean
 coverage-data-clean:
-	-rm -rf $(COVERAGE_PROFRAW) $(COVERAGE_PROFDATA) $(COVERAGE_DIR)/default.profraw
 	-find $(COVERAGE_DIR) -name '*.gcda' -delete 2>/dev/null
 
-.PHONY: coverage-report coverage-report-llvm coverage-report-gcov
+.PHONY: coverage-report
 coverage-report: coverage ## Generate an HTML coverage report and enforce the line floor
 	$(call require-tool,python3)
-	@if ls $(COVERAGE_PROFRAW)/*.profraw >/dev/null 2>&1; then \
-		$(MAKE) --no-print-directory coverage-report-llvm; \
-	else \
-		$(MAKE) --no-print-directory coverage-report-gcov; \
-	fi
-
-# Clang source-based coverage via llvm-cov (HTML + lcov + line floor).
-coverage-report-llvm:
-	$(LLVM_PROFDATA) merge -sparse $(COVERAGE_PROFRAW)/*.profraw -o $(COVERAGE_PROFDATA)
-	$(LLVM_COV) show $(COVERAGE_OBJECTS) -instr-profile=$(COVERAGE_PROFDATA) \
-		-format=html -output-dir=$(COVERAGE_DIR)/coverage-report $(COVERAGE_SOURCES)
-	$(LLVM_COV) export -format=lcov $(COVERAGE_OBJECTS) -instr-profile=$(COVERAGE_PROFDATA) \
-		$(COVERAGE_SOURCES) > $(COVERAGE_DIR)/coverage.lcov
-	$(LLVM_COV) report $(COVERAGE_OBJECTS) -instr-profile=$(COVERAGE_PROFDATA) $(COVERAGE_SOURCES)
-	$(LLVM_COV) export -summary-only $(COVERAGE_OBJECTS) -instr-profile=$(COVERAGE_PROFDATA) \
-		$(COVERAGE_SOURCES) | python3 -c 'import json, sys; \
-		pct = json.load(sys.stdin)["data"][0]["totals"]["lines"]["percent"]; floor = float(sys.argv[1]); \
-		print("line coverage %.1f%% (floor %s%%)" % (pct, sys.argv[1])); \
-		sys.exit(0 if pct >= floor else 1)' $(COVERAGE_FAIL_UNDER)
-
-# GCC gcov coverage via gcovr (HTML + Cobertura + line floor).
-coverage-report-gcov:
 	mkdir -p $(COVERAGE_DIR)/coverage-report
 	python3 -m gcovr --root . --gcov-executable "$(GCOV_EXECUTABLE)" \
 		--filter 'include/' --filter 'src/' --exclude 'tests/' \

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This repository uses:
 - [CMake](https://cmake.org) configure, build, and test presets as the public build interface
 - [Conan 2](https://conan.io) for dependency management
 - [spdlog](https://github.com/gabime/spdlog) via Conan as the sample compiled dependency
+- [CLI11](https://github.com/CLIUtils/CLI11) via Conan for command-line parsing
 - [GoogleTest](https://github.com/google/googletest) via Conan
 
 ## Operating model
@@ -154,11 +155,8 @@ The default `make bootstrap` does not install sanitizer-instrumented dependencie
 `make bootstrap-sanitize` or `make sanitize` when you need them.
 
 First-party targets are instrumented by the same Conan toolchain (the profile's
-`tools.build:*` flags reach the consumer), so the `sanitize` preset does not also set
-the CMake `ENABLE_SANITIZERS` option, which would double the flags. `ENABLE_SANITIZERS`
-remains a standalone option for instrumenting first-party code without the Conan
-profile, e.g. `cmake --preset debug -DENABLE_SANITIZERS=ON` (dependencies stay
-uninstrumented in that mode).
+`tools.build:*` flags reach the consumer), so the profiles are the single source of
+sanitizer flags.
 
 ### Tests
 
@@ -204,18 +202,12 @@ Build, test, and generate an HTML coverage report with an enforced line floor:
 make coverage-report
 ```
 
-Coverage supports both compilers and selects the matching toolchain automatically
-from the build artifacts:
+Both compilers emit gcov-format data (`--coverage`), reported by a single tool:
+[gcovr](https://gcovr.com) (`pip install gcovr`). It writes
+`coverage-report/index.html` and `coverage.xml` under `build/coverage/`.
 
-- **Clang / AppleClang**: source-based instrumentation reported by `llvm-cov`.
-  Writes `coverage-report/index.html` and `coverage.lcov` under `build/coverage/`.
-- **GCC**: `gcov` instrumentation reported by `gcovr` (`pip install gcovr`). Writes
-  `coverage-report/index.html` and `coverage.xml` under `build/coverage/`.
-
-The report fails if line coverage falls below `COVERAGE_FAIL_UNDER` (default 74;
-override with `make coverage-report COVERAGE_FAIL_UNDER=80`). `gcov` and `llvm-cov`
-count lines differently (gcov reports lower), so the floor tracks the gcov figure
-so both paths pass.
+The report fails if line coverage falls below `COVERAGE_FAIL_UNDER` (default 100;
+override with `make coverage-report COVERAGE_FAIL_UNDER=80`).
 
 ## Hardening
 
@@ -248,6 +240,8 @@ $ /path/to/prefix/bin/cpp_boilerplate
 [2026-06-30 20:46:16.431] [info] field 1: beta
 [2026-06-30 20:46:16.431] [info] field 2: gamma
 [2026-06-30 20:46:16.431] [info] done
+$ /path/to/prefix/bin/cpp_boilerplate --version
+0.1.0
 ```
 
 ## IDE setup

--- a/conan.lock
+++ b/conan.lock
@@ -3,7 +3,8 @@
     "requires": [
         "spdlog/1.17.0#bcbaaf7147bda6ad24ffbd1ac3d7142c%1767636069.964",
         "gtest/1.17.0#5224b3b3ff3b4ce1133cbdd27d53ee7d%1755784855.585",
-        "fmt/12.1.0#50abab23274d56bb8f42c94b3b9a40c7%1761885265.231"
+        "fmt/12.1.0#50abab23274d56bb8f42c94b3b9a40c7%1761885265.231",
+        "cli11/2.6.2#312ccb795ff5b571d9f4b1a3637b1eee%1776949795.774"
     ],
     "build_requires": [
         "cmake/3.25#platform"

--- a/conanfile.py
+++ b/conanfile.py
@@ -36,6 +36,7 @@ class CppBoilerplateConan(ConanFile):
         #   if self.settings.os == "Windows":
         #       self.requires("...")
         self.requires("spdlog/1.17.0")
+        self.requires("cli11/2.6.2")
 
     def validate(self):
         # Require C++23 at the standard level (catches a profile pinning an older

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,10 +1,12 @@
 #include <cpp_boilerplate/split.hpp>
 #include <cpp_boilerplate/version.hpp>
 
+#include <CLI/CLI.hpp>
 #include <spdlog/spdlog.h>
 
 #include <cstddef>
 #include <exception>
+#include <string>
 #include <string_view>
 
 namespace {
@@ -26,12 +28,22 @@ void run()
 
 } // namespace
 
+// CLI11 setup before the try block throws only on programmer error.
 // NOLINTNEXTLINE(bugprone-exception-escape)
-int main()
+int main(int argc, char* argv[])
 {
+    CLI::App app{"Modern C++23 project template demo"};
+    app.set_version_flag("--version", std::string{cpp_boilerplate::version});
+    // Handles --help, --version, and argument errors, exiting with the right code.
+    CLI11_PARSE(app, argc, argv);
+
+    // Defensive scaffolding: nothing in the app throws today, so the handlers are
+    // excluded from coverage rather than left as uncovered lines or tested through
+    // artificial hooks.
     try {
         run();
         return 0;
+        // LCOV_EXCL_START
     }
     catch (const std::exception& error) {
         spdlog::critical("fatal: {}", error.what());
@@ -40,4 +52,5 @@ int main()
         spdlog::critical("fatal: unknown exception");
     }
     return 1;
+    // LCOV_EXCL_STOP
 }


### PR DESCRIPTION
Single squashed commit. Started as "close the gcov-vs-llvm coverage gap"; five review rounds reshaped it into a broader simplification.

## Command line via CLI11

`cli11/2.6.2` via Conan. `main()` uses `CLI::App` with `set_version_flag` — `--version` and `--help` come built in, and an unknown argument is a genuine error path (CLI11 ParseError, nonzero exit), smoke-tested rather than test-hooked. The `try/catch` around `run()` is defensive scaffolding, excluded from coverage with standard `LCOV_EXCL_START/STOP` markers; one clang-gcov quirk (the try's closing brace counts as an exception-dispatch line) is handled by marker placement.

## Coverage: one mechanism, meaningful floor

Both compilers emit gcov-format data via `--coverage`; gcovr is the single reporter (`llvm-cov gcov` reads clang's data, wired in the Makefile) and honors the exclusion markers natively in the floor check and HTML report alike. The llvm-cov source-based path — and the custom floor-check script its missing marker support had forced — is gone. Floor raised 74 → 100: with every path exercised both toolchains agree exactly, so new sample code arrives tested. `enable_coverage` adds only `--coverage` (Debug config already implies `-O0 -g`).

## Simplifications from review

- `ENABLE_SANITIZERS` and `enable_sanitizers()` removed: Conan profiles are the single source of sanitizer flags; the hardening guard reduced to the option itself (the coverage/sanitize presets are Debug, so the fortify genex already keeps them compatible).
- `clang-analyzer-*` dropped from clang-tidy (with it, a NewDeleteLeaks false-positive workaround for CLI11 headers).
- Rationale comments trimmed to repo-normal density; the `main()` NOLINT re-verified as still required (CLI11 setup precedes the try block).
- Test target renamed `split_test` → `cpp_boilerplate_test`.

## CMake style tooling

`CMakeLists.txt` reformatted at line width 100 / indent 4, with both linter configs aligned: `.cmake-format.yaml` keys moved under `format:` where the cmakelang schema reads them (plus a `lint:` section disabling C0111 docstring demands), and a new `.cmakelintrc` covers the standalone cmakelint tool (`linelength=100`, indent heuristic off — it fights cmake-format's continuation alignment). Verified: `cmake-format --check`, `cmake-lint`, and `cmakelint` all pass.

## Verification

Local (AppleClang): coverage 100.0% (23/23) via `xcrun llvm-cov gcov` + gcovr; debug/release/sanitize suites green (10 tests: 6 unit + 4 smoke covering the normal run, `--version`, `--help`, and `--bogus`); clang-tidy, clang-format, and all three CMake style tools clean. CI: all 12 checks green, including the gcc/gcovr coverage job at floor 100 and MSVC building CLI11.