### PR TITLE
build: enable colored diagnostics

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,10 @@ include(CTest)
 
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+set(CMAKE_COLOR_DIAGNOSTICS
+    ON
+    CACHE BOOL "Enable color diagnostics in generated build systems"
+)
 
 option(WARNINGS_AS_ERRORS "Treat warnings as errors" ON)
 option(ENABLE_COVERAGE "Enable code coverage instrumentation" OFF)

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,10 @@ COLOR_CYAN := \033[36m
 COLOR_RED := \033[31m
 COLOR_RESET := \033[0m
 
+CLICOLOR ?= 1
+GTEST_COLOR ?= 1
+export CLICOLOR GTEST_COLOR
+
 # Fail the recipe with a red ERROR message on stderr: $(DIE) "message". %b expands
 # \n for multi-line messages. A sh -c one-liner (message as shell arg $0) rather than
 # a $(call ...) macro because call splits its arguments on the commas messages contain.


### PR DESCRIPTION
## Summary
- enable CMake's generated-build color diagnostics
- export `CLICOLOR` and `GTEST_COLOR` from the Makefile wrapper

## Tests
- `git diff --check`
- `cmake -U CMAKE_COLOR_DIAGNOSTICS --preset debug`
- `make debug`