### PR TITLE
ci: add GitHub security automation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "America/Los_Angeles"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    open-pull-requests-limit: 5

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,36 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "37 9 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: codeql / ubuntu-latest / cpp
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      packages: read
+      security-events: write
+    env:
+      CONAN_VERSION: "2.29.1"
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: github/codeql-action/init@v3
+        with:
+          languages: c-cpp
+      - uses: conan-io/setup-conan@v1
+        with:
+          version: ${{ env.CONAN_VERSION }}
+          cache_packages: true
+      - run: make release
+      - uses: github/codeql-action/analyze@v3

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,13 @@
+# Security Policy
+
+## Supported Versions
+
+This repository is a template. Security fixes apply to the current `main` branch.
+
+## Reporting a Vulnerability
+
+Please report suspected vulnerabilities through GitHub private vulnerability reporting instead of
+opening a public issue. Include the affected revision, steps to reproduce, expected impact, and any
+suggested fix.
+
+We will triage reports and coordinate fixes through GitHub Security Advisories when needed.


### PR DESCRIPTION
## Summary
- add Dependabot updates for GitHub Actions
- add a C++ CodeQL workflow using the existing Conan release build path
- add a security policy that points reports to private vulnerability reporting

## Verification
- ruby -e 'require "yaml"; ARGV.each { |path| YAML.load_file(path) }; puts "yaml ok"' .github/dependabot.yml .github/workflows/build.yml .github/workflows/codeql.yml
- git diff --staged --check

## Notes
- GitHub repository settings were also updated: Dependabot security updates, secret scanning, push protection, private vulnerability reporting, squash-only merge policy, and active main/tag rulesets.