### PR TITLE
docs: publish Doxygen API docs

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,51 @@
+name: Pages
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+env:
+  CONAN_VERSION: "2.29.1"
+
+jobs:
+  build:
+    name: doxygen / ubuntu-latest
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: conan-io/setup-conan@v1
+        with:
+          version: ${{ env.CONAN_VERSION }}
+          cache_packages: true
+      - run: sudo apt-get install -y doxygen
+      - run: make docs
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v4
+        with:
+          path: build/docs/html
+
+  deploy:
+    name: deploy / github-pages
+    if: github.event_name != 'pull_request'
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,7 @@ endif()
 
 find_package(spdlog CONFIG REQUIRED)
 find_package(CLI11 CONFIG REQUIRED)
+find_package(Doxygen QUIET)
 
 function(enable_project_warnings target)
     if(MSVC)
@@ -114,6 +115,33 @@ enable_project_options(cpp_boilerplate)
 # public deliverable, so it is deliberately not installed or exported.
 include(GNUInstallDirs)
 install(TARGETS cpp_boilerplate RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+# --- documentation ---------------------------------------------------------
+if(Doxygen_FOUND)
+    set(DOXYGEN_EXTRACT_ALL NO)
+    set(DOXYGEN_FULL_PATH_NAMES NO)
+    set(DOXYGEN_HTML_OUTPUT html)
+    set(DOXYGEN_MARKDOWN_ID_STYLE GITHUB)
+    set(DOXYGEN_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR})
+    set(DOXYGEN_SOURCE_BROWSER YES)
+    set(DOXYGEN_STRIP_FROM_PATH ${PROJECT_SOURCE_DIR})
+    set(DOXYGEN_USE_MDFILE_AS_MAINPAGE ${PROJECT_SOURCE_DIR}/README.md)
+    set(DOXYGEN_WARN_AS_ERROR YES)
+
+    doxygen_add_docs(
+        docs
+        ${PROJECT_SOURCE_DIR}/README.md
+        ${PROJECT_SOURCE_DIR}/include
+        WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+        COMMENT "Generate API documentation"
+    )
+else()
+    add_custom_target(
+        docs
+        COMMAND ${CMAKE_COMMAND} -E echo "Doxygen not found. Install Doxygen to build docs."
+        COMMAND ${CMAKE_COMMAND} -E false
+    )
+endif()
 
 # --- tests -----------------------------------------------------------------
 if(BUILD_TESTING)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -49,6 +49,17 @@
       "cacheVariables": {
         "ENABLE_COVERAGE": "ON"
       }
+    },
+    {
+      "name": "docs",
+      "displayName": "Docs",
+      "description": "Doxygen documentation build. Reuses the debug Conan toolchain.",
+      "inherits": "debug",
+      "binaryDir": "${sourceDir}/build/docs",
+      "toolchainFile": "${sourceDir}/build/debug/generators/conan_toolchain.cmake",
+      "cacheVariables": {
+        "BUILD_TESTING": "OFF"
+      }
     }
   ],
   "buildPresets": [
@@ -81,6 +92,12 @@
       "name": "coverage",
       "configurePreset": "coverage",
       "configuration": "Debug"
+    },
+    {
+      "name": "docs",
+      "configurePreset": "docs",
+      "configuration": "Debug",
+      "targets": ["docs"]
     }
   ],
   "testPresets": [

--- a/Makefile
+++ b/Makefile
@@ -128,6 +128,11 @@ sanitize: ## Build and test via the sanitize workflow preset
 .PHONY: coverage
 coverage: coverage-data-clean ## Build and test via the coverage workflow preset
 
+.PHONY: docs
+docs: $(STAMP_DIR)/debug.stamp ## Generate Doxygen HTML documentation
+	cmake --preset docs
+	cmake --build --preset docs
+
 debug release sanitize coverage: %: $(STAMP_DIR)/$$(CONAN_STAMP_%).stamp
 	cmake --workflow --preset $@
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # C++ Boilerplate
 
 [![Build](https://github.com/megabyde/cpp-boilerplate/actions/workflows/build.yml/badge.svg)](https://github.com/megabyde/cpp-boilerplate/actions/workflows/build.yml)
+[![Pages](https://github.com/megabyde/cpp-boilerplate/actions/workflows/pages.yml/badge.svg)](https://github.com/megabyde/cpp-boilerplate/actions/workflows/pages.yml)
 [![C++23](https://img.shields.io/badge/C%2B%2B-23-blue.svg)](https://en.cppreference.com/w/cpp/23)
 [![CMake](https://img.shields.io/badge/CMake-3.25%2B-064F8C.svg)](https://cmake.org)
 [![Conan](https://img.shields.io/badge/Conan-2.x-6699CB.svg)](https://conan.io)
@@ -18,6 +19,7 @@ This repository uses:
 - [spdlog](https://github.com/gabime/spdlog) via Conan as the sample compiled dependency
 - [CLI11](https://github.com/CLIUtils/CLI11) via Conan for command-line parsing
 - [GoogleTest](https://github.com/google/googletest) via Conan
+- [Doxygen](https://www.doxygen.nl) for generated API documentation
 
 ## Operating model
 
@@ -47,6 +49,7 @@ stable across toolchain changes.
 - [Ninja](https://ninja-build.org/) (optional, Unix only; GNU Make is used when absent)
 - [ccache](https://ccache.dev/) (optional; used automatically for first-party targets when on
   PATH — not with the Visual Studio generator, which ignores compiler launchers)
+- [Doxygen](https://www.doxygen.nl) (optional; required only for `make docs`)
 - A compiler and standard library with working C++23 support
   - [GCC](https://gcc.gnu.org/) 13+
   - [LLVM Clang](https://llvm.org/) 17+
@@ -166,8 +169,10 @@ project leaves it at the default `ON`, so `make debug`, `make release`, `make sa
 
 ## Public presets
 
-- Configure presets: `debug`, `release`, `sanitize`, `sanitize-asan`, `sanitize-ubsan`, `coverage`
-- Build presets: `debug`, `release`, `sanitize`, `sanitize-asan`, `sanitize-ubsan`, `coverage`
+- Configure presets: `debug`, `release`, `sanitize`, `sanitize-asan`, `sanitize-ubsan`,
+  `coverage`, `docs`
+- Build presets: `debug`, `release`, `sanitize`, `sanitize-asan`, `sanitize-ubsan`, `coverage`,
+  `docs`
 - Test presets: `debug`, `release`, `sanitize`, `sanitize-asan`, `sanitize-ubsan`, `coverage`
 - Workflow presets: `debug`, `release`, `sanitize`, `sanitize-asan`, `sanitize-ubsan`, `coverage` (configure + build + test)
 
@@ -208,6 +213,17 @@ Both compilers emit gcov-format data (`--coverage`), reported by a single tool:
 
 The report fails if line coverage falls below `COVERAGE_FAIL_UNDER` (default 100;
 override with `make coverage-report COVERAGE_FAIL_UNDER=80`).
+
+## Documentation
+
+Generate Doxygen HTML documentation locally:
+
+```console
+make docs
+```
+
+The output is written to `build/docs/html/`. GitHub Pages builds the same target and publishes the
+result from the `main` branch.
 
 ## Hardening
 

--- a/include/cpp_boilerplate/split.hpp
+++ b/include/cpp_boilerplate/split.hpp
@@ -4,10 +4,13 @@
 #include <string_view>
 #include <vector>
 
+/// Public API for the template application.
 namespace cpp_boilerplate {
 
-// The returned fields alias the storage backing `record`. The caller must keep that
-// buffer alive for as long as the results are used; passing a temporary string dangles.
+/// Lazily split a string view into fields.
+///
+/// The returned fields alias the storage backing `record`. The caller must keep that
+/// buffer alive for as long as the results are used; passing a temporary string dangles.
 [[nodiscard]] constexpr auto split_views(std::string_view record, char delimiter = ',')
 {
     return record | std::views::split(delimiter) | std::views::transform([](auto subrange) {
@@ -15,6 +18,9 @@ namespace cpp_boilerplate {
            });
 }
 
+/// Split a string view into an owning vector of field views.
+///
+/// The returned field views still alias the storage backing `record`.
 [[nodiscard]] std::vector<std::string_view> split_views_vec(std::string_view record,
                                                             char delimiter = ',');
 


### PR DESCRIPTION
## Summary
- add a Doxygen-backed docs target exposed through CMake presets and make docs
- publish build/docs/html with a GitHub Pages workflow
- document the public API surface enough for Doxygen to generate reference pages
- add README docs usage and Pages workflow badge

## Verification
- make docs
- make debug
- make format-check
- ruby -e 'require "json"; ARGV.each { |path| JSON.parse(File.read(path)) }; puts "json ok"' CMakePresets.json
- ruby -e 'require "yaml"; ARGV.each { |path| YAML.load_file(path) }; puts "yaml ok"' .github/workflows/build.yml .github/workflows/pages.yml
- git diff --check

## Notes
- GitHub Pages is already enabled for this repository with build_type=workflow.
- Pages URL: https://megabyde.github.io/cpp-boilerplate/
- Doxygen warnings are treated as errors through DOXYGEN_WARN_AS_ERROR.