### PR TITLE
Doxygen/style fixes: pin Doxygen 1.17.0, wire LICENSE into docs, drop em-dashes

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -16,6 +16,9 @@ permissions:
 
 env:
   CONAN_VERSION: "2.29.1"
+  # Ubuntu's apt package (1.9.8 on noble) trails upstream by years; install the pinned
+  # release directly instead.
+  DOXYGEN_VERSION: "1.17.0"
 
 jobs:
   build:
@@ -27,7 +30,11 @@ jobs:
         with:
           version: ${{ env.CONAN_VERSION }}
           cache_packages: true
-      - run: sudo apt-get install -y doxygen
+      - name: Install Doxygen
+        run: |
+          version="${{ env.DOXYGEN_VERSION }}"
+          curl -sL "https://github.com/doxygen/doxygen/releases/download/Release_${version//./_}/doxygen-${version}.linux.bin.tar.gz" | tar -xz
+          echo "$PWD/doxygen-${version}/bin" >> "$GITHUB_PATH"
       - run: make docs
       - uses: actions/configure-pages@v5
       - uses: actions/upload-pages-artifact@v4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,6 +120,10 @@ install(TARGETS cpp_boilerplate RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 if(Doxygen_FOUND)
     set(DOXYGEN_EXTRACT_ALL NO)
     set(DOXYGEN_FULL_PATH_NAMES NO)
+    # Copies LICENSE next to index.html so README's license badge (a relative ./LICENSE link)
+    # resolves in the generated site too; Doxygen does not rewrite that link on its own, since a
+    # bare LICENSE has no extension it treats as a documentable page type.
+    set(DOXYGEN_HTML_EXTRA_FILES ${PROJECT_SOURCE_DIR}/LICENSE)
     set(DOXYGEN_HTML_OUTPUT html)
     set(DOXYGEN_MARKDOWN_ID_STYLE GITHUB)
     set(DOXYGEN_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR})
@@ -128,9 +132,10 @@ if(Doxygen_FOUND)
     set(DOXYGEN_USE_MDFILE_AS_MAINPAGE ${PROJECT_SOURCE_DIR}/README.md)
     set(DOXYGEN_WARN_AS_ERROR YES)
 
+    # LICENSE is also listed as an input (not just HTML_EXTRA_FILES) so editing it invalidates the
+    # docs target and it shows up in the source browser.
     doxygen_add_docs(
-        docs
-        ${PROJECT_SOURCE_DIR}/README.md
+        docs ${PROJECT_SOURCE_DIR}/README.md ${PROJECT_SOURCE_DIR}/LICENSE
         ${PROJECT_SOURCE_DIR}/include
         WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
         COMMENT "Generate API documentation"
@@ -153,9 +158,9 @@ if(BUILD_TESTING)
 
     gtest_discover_tests(cpp_boilerplate_test DISCOVERY_MODE PRE_TEST)
 
-    # Smoke tests: exercise the application binary end to end — the normal run, the --version and
-    # --help branches, and the error path (unknown argument -> nonzero exit). Together they cover
-    # all of src/main.cpp, including under the sanitizer and coverage presets.
+    # Smoke tests: exercise the application binary end to end, covering the normal run, the
+    # --version and --help branches, and the error path (unknown argument -> nonzero exit). Together
+    # they cover all of src/main.cpp, including under the sanitizer and coverage presets.
     add_test(NAME AppTest.RunsToCompletion COMMAND cpp_boilerplate)
     set_tests_properties(AppTest.RunsToCompletion PROPERTIES PASS_REGULAR_EXPRESSION "done")
 

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ ifneq ($(VERBOSE),1)
 endif
 
 # ---------------------------------------------------------------------------
-# Conan configuration — release gets its own profile state, coverage reuses the
+# Conan configuration: release gets its own profile state, coverage reuses the
 # debug toolchain (its dependency graph is identical to Debug), and sanitize uses
 # a dedicated profile plus a custom compiler.sanitizer setting (conan/settings_user.yml)
 # so instrumented dependency binaries get a distinct package_id and are rebuilt
@@ -63,7 +63,7 @@ define require-tool
 endef
 
 # ---------------------------------------------------------------------------
-# Conan lock file (lazy — regenerated when conanfile.py changes)
+# Conan lock file (lazy: regenerated when conanfile.py changes)
 # ---------------------------------------------------------------------------
 # --lockfile-clean drops entries the current graph no longer uses; without it,
 # `conan lock create` merges into the existing lock and stale pins accumulate after

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![C++23](https://img.shields.io/badge/C%2B%2B-23-blue.svg)](https://en.cppreference.com/w/cpp/23)
 [![CMake](https://img.shields.io/badge/CMake-3.25%2B-064F8C.svg)](https://cmake.org)
 [![Conan](https://img.shields.io/badge/Conan-2.x-6699CB.svg)](https://conan.io)
-[![License](https://img.shields.io/badge/license-Unlicense-green.svg)](LICENSE)
+[![License](https://img.shields.io/badge/license-Unlicense-green.svg)](./LICENSE)
 
 ## Overview
 
@@ -61,7 +61,7 @@ stable across toolchain changes.
 - [Conan](https://docs.conan.io/2/installation.html) 2.25+ (for the `CMakeConfigDeps` generator)
 - [Ninja](https://ninja-build.org/) (optional, Unix only; GNU Make is used when absent)
 - [ccache](https://ccache.dev/) (optional; used automatically for first-party targets when on
-  PATH — not with the Visual Studio generator, which ignores compiler launchers)
+  PATH; not with the Visual Studio generator, which ignores compiler launchers)
 - [Doxygen](https://www.doxygen.nl) (optional; required only for `make docs`)
 - A compiler and standard library with working C++23 support
   - [GCC](https://gcc.gnu.org/) 13+
@@ -125,10 +125,10 @@ shared base, [`profiles/sanitize-common`](profiles/sanitize-common) (which pulls
 `profiles/default`, sets `Debug`, and carries the common instrumentation flags and `[runenv]`),
 and appends its own `-fsanitize` flags:
 
-- `sanitize` — combined ASan + UBSan ([`profiles/sanitize`](profiles/sanitize)); driven by
+- `sanitize`: combined ASan + UBSan ([`profiles/sanitize`](profiles/sanitize)); driven by
   `make sanitize` and CI.
-- `sanitize-asan` — AddressSanitizer only ([`profiles/sanitize-asan`](profiles/sanitize-asan)).
-- `sanitize-ubsan` — UndefinedBehaviorSanitizer only
+- `sanitize-asan`: AddressSanitizer only ([`profiles/sanitize-asan`](profiles/sanitize-asan)).
+- `sanitize-ubsan`: UndefinedBehaviorSanitizer only
   ([`profiles/sanitize-ubsan`](profiles/sanitize-ubsan)).
 
 Each `make sanitize*` target installs the matching instrumented dependency graph, then runs the
@@ -140,7 +140,7 @@ Each mode gets its own `package_id` and build tree (`build/debug-address`,
 ASan/UBSan runtime options (`halt_on_error`, `print_stacktrace`, and related checks) live in
 `profiles/sanitize-common` under `[runenv]` (inherited by every mode). Conan injects them into
 the generated per-mode test preset, which the public `sanitize*` test preset inherits, so
-`ctest`/`cmake --workflow` runs the instrumented tests with those options — a single source of
+`ctest`/`cmake --workflow` runs the instrumented tests with those options: a single source of
 truth, no duplication in `CMakePresets.json`.
 
 That separation relies on a custom `compiler.sanitizer` setting defined in


### PR DESCRIPTION
## Summary
- Pin the Pages workflow's Doxygen to 1.17.0 (a real release binary), replacing apt's stale 1.9.8 on Ubuntu noble.
- Wire `LICENSE` into the Doxygen build so the README's license badge resolves in the generated site instead of 404ing; also make the badge link explicitly relative (`./LICENSE`).
- Replace em-dashes in comments/docs with plain punctuation.

## Test plan
- [x] `cmake --preset docs && cmake --build --preset docs` locally; confirmed `build/docs/html/LICENSE` exists and is byte-identical to the source, and `index.html`'s badge link resolves to it.
- [x] Verified the `doxygen-1.17.0.linux.bin.tar.gz` release asset URL resolves and the binary is a valid dynamically-linked Linux ELF.
- [ ] CI (Pages workflow) — not run in this session; will be exercised on push.