### PR TITLE
build: enforce cmake-format and make every clang-tidy check an error

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,8 +1,7 @@
 FormatStyle: file
-WarningsAsErrors: >
-  bugprone-*,
-  performance-*,
-  -performance-avoid-endl
+# Every enabled check gates the build: clang-tidy exits nonzero only on errors, so
+# anything short of '*' here lets findings print in CI without failing it.
+WarningsAsErrors: '*'
 HeaderFilterRegex: '^(include|src|tests)/'
 
 Checks: >

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,7 @@ env:
   CONAN_VERSION: "2.29.1"
   CLANG_FORMAT_VERSION: "21.1.8"
   CLANG_TIDY_VERSION: "21.1.6"
+  CMAKELANG_VERSION: "0.6.13"
 
 jobs:
   build:
@@ -134,7 +135,8 @@ jobs:
         run: |
           python3 -m pip install --break-system-packages --user \
             clang-format==${{ env.CLANG_FORMAT_VERSION }} \
-            clang-tidy==${{ env.CLANG_TIDY_VERSION }}
+            clang-tidy==${{ env.CLANG_TIDY_VERSION }} \
+            cmakelang==${{ env.CMAKELANG_VERSION }}
       - run: make bootstrap
       - run: make format-check
       - run: make lint

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -172,8 +172,13 @@ if(BUILD_TESTING)
     add_test(NAME AppTest.PrintsHelp COMMAND cpp_boilerplate --help)
     set_tests_properties(AppTest.PrintsHelp PROPERTIES PASS_REGULAR_EXPRESSION "OPTIONS")
 
-    # WILL_FAIL inverts the exit-code check: the test passes because the app exits nonzero on an
-    # unknown argument.
+    # PASS_REGULAR_EXPRESSION (not WILL_FAIL): the CLI11 diagnostic proves the error branch ran and
+    # reported, while an exit-code inversion is also satisfied by a crash. The two properties cannot
+    # combine on one test: the regex verdict replaces the exit-code check, and WILL_FAIL would
+    # invert it into a deterministic failure.
     add_test(NAME AppTest.RejectsUnknownArgument COMMAND cpp_boilerplate --bogus)
-    set_tests_properties(AppTest.RejectsUnknownArgument PROPERTIES WILL_FAIL TRUE)
+    set_tests_properties(
+        AppTest.RejectsUnknownArgument PROPERTIES PASS_REGULAR_EXPRESSION
+                                                  "argument was not expected: --bogus"
+    )
 endif()

--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,7 @@ SANITIZE_STAMPS := \
 	$(STAMP_DIR)/sanitize-asan.stamp \
 	$(STAMP_DIR)/sanitize-ubsan.stamp
 FORMAT_SOURCES = $(shell find include src tests -type f \( -name '*.hpp' -o -name '*.cpp' \))
+CMAKE_FORMAT_SOURCES = CMakeLists.txt
 TIDY_SOURCES = $(shell find src tests -type f -name '*.cpp')
 
 define require-tool
@@ -172,16 +173,22 @@ lint: $(STAMP_DIR)/debug.stamp ## Run clang-tidy against the debug compilation d
 	PATH="$(PATH)" clang-tidy -p build/debug $(TIDY_SOURCES)
 
 .PHONY: format
-format: ## Format C++ sources in place with clang-format
+format: ## Format C++ and CMake sources in place
 	echo "Formatting C++ sources..."
 	$(call require-tool,clang-format)
 	PATH="$(PATH)" clang-format -i $(FORMAT_SOURCES)
+	echo "Formatting CMake sources..."
+	$(call require-tool,cmake-format)
+	cmake-format -i $(CMAKE_FORMAT_SOURCES)
 
 .PHONY: format-check
-format-check: ## Fail if C++ sources are not clang-format clean
+format-check: ## Fail if C++ or CMake sources are not format-clean
 	echo "Checking C++ formatting..."
 	$(call require-tool,clang-format)
 	PATH="$(PATH)" clang-format --dry-run --Werror $(FORMAT_SOURCES)
+	echo "Checking CMake formatting..."
+	$(call require-tool,cmake-format)
+	cmake-format --check $(CMAKE_FORMAT_SOURCES)
 
 # ---------------------------------------------------------------------------
 # Lock and clean

--- a/README.md
+++ b/README.md
@@ -195,6 +195,10 @@ make format-check
 make lint
 ```
 
+`make format` and `make format-check` cover C++ sources (clang-format) and `CMakeLists.txt`
+(cmake-format, from the [cmakelang](https://cmake-format.readthedocs.io) package). `make lint`
+runs clang-tidy against the debug compilation database; every enabled check is an error.
+
 ## Coverage
 
 Build, test, and generate an HTML coverage report with an enforced line floor:


### PR DESCRIPTION
Part 1 of the holistic-review plan (lint-surface consistency).

## What

- **Wire cmake-format into `make format`/`format-check` and the CI lint job** (pinned `cmakelang==0.6.13`). `.cmake-format.yaml` existed but nothing ran it; `CMakeLists.txt` was already clean, so there is no reformat churn.
- **`.clang-tidy`: `WarningsAsErrors: '*'`.** clang-tidy exits nonzero only on errors, so the previous bugprone/performance-only list let modernize/readability/misc findings print in CI without failing it. The codebase is already clean under '*'.
- **Check the CLI11 diagnostic in the unknown-argument smoke test** instead of `WILL_FAIL`: the message proves the error branch ran and reported, while an exit-code inversion is also satisfied by a crash. The two properties cannot combine on one test (verified empirically: the regex verdict replaces the exit-code check and WILL_FAIL inverts it into a deterministic failure).

## Verification

- `make format-check`, `make lint`, and `make debug` green locally (10/10 tests).
- clang-tidy under `WarningsAsErrors: '*'`: 0 errors, 3 pre-existing NOLINTs honored.
- Reviewed locally in revdiff.